### PR TITLE
Improvements to hyphenation and hyphenation related code

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>braille-common</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
@@ -62,19 +62,19 @@
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>libhyphen-utils</artifactId>
         <classifier>linux</classifier>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>libhyphen-utils</artifactId>
         <classifier>mac</classifier>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>libhyphen-utils</artifactId>
         <classifier>windows</classifier>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
       </dependency>
       <!-- list main liblouis-utils first because this determines the version of the 'doc' artifact picked for the website -->
       <dependency>
@@ -86,29 +86,29 @@
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>liblouis-utils</artifactId>
         <classifier>linux</classifier>
-        <version>5.0.0</version>
+        <version>5.1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>liblouis-utils</artifactId>
         <classifier>mac</classifier>
-        <version>5.0.0</version>
+        <version>5.1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>liblouis-utils</artifactId>
         <classifier>windows</classifier>
-        <version>5.0.0</version>
+        <version>5.1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>pef-utils</artifactId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>texhyph-utils</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
       </dependency>
       
       <!--

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -45,7 +45,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>braille-css-utils</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>libhyphen-utils</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
@@ -80,7 +80,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>liblouis-utils</artifactId>
-        <version>5.0.3-SNAPSHOT</version>
+        <version>5.1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>

--- a/braille/braille-common/pom.xml
+++ b/braille/braille-common/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.daisy.pipeline.modules.braille</groupId>
   <artifactId>braille-common</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: braille-common</name>

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/AbstractBrailleTranslator.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/AbstractBrailleTranslator.java
@@ -18,16 +18,17 @@ import cz.vutbr.web.css.CSSProperty;
 import cz.vutbr.web.css.TermInteger;
 import cz.vutbr.web.css.TermString;
 
-import org.daisy.dotify.api.table.BrailleConverter;
-import static org.daisy.pipeline.braille.common.util.Strings.extractHyphens;
-import static org.daisy.pipeline.braille.common.util.Tuple2;
 import org.daisy.braille.css.BrailleCSSProperty.HyphenateCharacter;
 import org.daisy.braille.css.BrailleCSSProperty.Hyphens;
 import org.daisy.braille.css.BrailleCSSProperty.WhiteSpace;
 import org.daisy.braille.css.BrailleCSSProperty.WordSpacing;
 import org.daisy.braille.css.SimpleInlineStyle;
+import org.daisy.dotify.api.table.BrailleConverter;
 import org.daisy.dotify.api.translator.UnsupportedMetricException;
 import org.daisy.dotify.api.translator.BrailleTranslatorResult;
+import static org.daisy.pipeline.braille.common.util.Strings.extractHyphens;
+import static org.daisy.pipeline.braille.common.util.Tuple2;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 import org.slf4j.Logger;
 

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/AbstractBrailleTranslator.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/AbstractBrailleTranslator.java
@@ -162,16 +162,16 @@ public abstract class AbstractBrailleTranslator extends AbstractTransform implem
 			 * white space and perform line breaking outside or at the boundaries of words
 			 * (according to the CSS rules), but it doesn't need to because the result will be
 			 * passed though a white space processing and line breaking stage anyway. Preserved
-			 * spaces MUST be converted to NBSP characters. Line breaking may be "explicit" by
-			 * indicating that the end of a line has been reached, by returning an empty string the
-			 * next time the next() method is called (and `limit` &gt; 0). The returned string is
-			 * normally smaller or equal to `limit` in this case. The "allowHyphens" argument must
-			 * be respected, and a hyphen character at the end the line MUST be inserted when
-			 * hyphenating. If it's a soft hyphen (SHY) it will be substituted with a real hyphen
-			 * automatically. If line breaking is "implicit", it is left up to the line breaking
-			 * stage. Preserved line breaks MUST be converted to LS characters in this case, and
-			 * other break characters (SHY, ZWSP) MUST be included for all break opportunities,
-			 * including those within words, regardless of the "allowHyphens" argument.
+			 * spaces MUST be converted to NBSP characters. Line breaking may be "explicit" by not
+			 * providing more characters than those that may be put on the current line. The
+			 * "allowHyphens" argument must be respected, and a hyphen character at the end the line
+			 * MUST be inserted when hyphenating. If it's a soft hyphen (SHY) it will be substituted
+			 * with a real hyphen automatically. If line breaking is "implicit", it is left up to
+			 * the line breaking stage. Preserved line breaks MUST be converted to LS characters in
+			 * this case, and other break characters (SHY, ZWSP) MUST be included for all break
+			 * opportunities, including those within words, regardless of the "allowHyphens"
+			 * argument. There is a break opportunity after each string returned by the {@link
+			 * BrailleStream}.
 			 */
 			protected abstract BrailleStream translateAndHyphenate(Iterable<CSSStyledText> text, int from, int to);
 			
@@ -271,7 +271,7 @@ public abstract class AbstractBrailleTranslator extends AbstractTransform implem
 					this(string, 0, -1);
 				}
 				public FullyHyphenatedAndTranslatedString(String string, int from, int to) {
-					this(string, from, to, '\u2824');
+					this(string, from, to, SHY); // LineIterator converts SHY at the end of a line to a hyphen character
 				}
 				public FullyHyphenatedAndTranslatedString(String string, int from, int to, char hyphenChar) {
 					// if there are no preceding segments, assume that we are at the beginning of a line,
@@ -302,8 +302,15 @@ public abstract class AbstractBrailleTranslator extends AbstractTransform implem
 								lastWordPart = next.substring(lastWordStart, to);
 								lastWordOtherPart = next.substring(to, lastWordEnd);
 								next = next.substring(0, lastWordStart);
+								// ZWSP is not considered a WORD_BOUNDARY, but a word should not start with a ZWSP
+								lastWordPart = lastWordPart.replaceAll("^\u200b*", "");
+								if (lastWordPart.isEmpty())
+									lastWordPart = lastWordOtherPart = null;
 							}
 						}
+					} else {
+						// remove SHY at end of stream because it would be converted to hyphen character
+						next = next.replaceAll("\u00ad$", "");
 					}
 					if (next.replaceAll("[\u00ad\u200b]","").isEmpty())
 						next = null;
@@ -355,7 +362,6 @@ public abstract class AbstractBrailleTranslator extends AbstractTransform implem
 										String n = lastWord.substring(0, i);
 										// FIXME: don't hard-code the number 1
 										if ((hyphens[i - 1] & 1) == 1)
-											// don't use SHY because it would be dropped by LineIterator if no more characters follow
 											n += hyphenChar;
 										lastWordPart = nextLastWordPart.substring(i);
 										if (lastWordPart.isEmpty()) lastWordPart = null;
@@ -478,20 +484,23 @@ public abstract class AbstractBrailleTranslator extends AbstractTransform implem
 				 */
 				private void fillRow(int limit, boolean force, boolean allowHyphens) {
 					int bufSize = charBuffer.length();
-				  loop: while (true) {
-						if (inputBuffer == null || !inputBuffer.hasNext()) {
+					while (true) {
+						if (inputBuffer != null && !inputBuffer.hasNext()) {
+							// there is a break opportunity after each string returned by the stream
+							// we keep soft hyphens at the end of the string (also if we are at the very end of the stream)
+							if (bufSize > 0 && wrapInfo.get(bufSize - 1) != SOFT_WRAP_WITH_HYPHEN)
+								wrapInfo.set(bufSize - 1, (byte)(wrapInfo.get(bufSize - 1) | SOFT_WRAP_WITHOUT_HYPHEN));
 							inputBuffer = null;
-							if (!inputStream.hasNext()) {} // end of stream
-							else if (bufSize < limit) {
+						}
+						if (inputBuffer == null) {
+							if (!inputStream.hasNext()) // end of stream
+								return;
+							if (bufSize < limit) {
 								String next = inputStream.next(limit - bufSize, force && (bufSize == 0), allowHyphens);
-								if (next.isEmpty()) {} // row full according to input feed
-								else
-									inputBuffer = peekingIterator(charactersOf(next).iterator()); }
+								if (next.isEmpty()) // row full according to input feed
+									return;
+								inputBuffer = peekingIterator(charactersOf(next).iterator()); }
 							if (inputBuffer == null) {
-								if (!inputStream.hasNext()) { // end of stream
-									if (bufSize > 0)
-										wrapInfo.set(bufSize - 1, (byte)(wrapInfo.get(bufSize - 1) | SOFT_WRAP_WITHOUT_HYPHEN));
-									return; }
 								switch (inputStream.peek()) {
 								case SHY:    case TAB:
 								case ZWSP:   case BLANK:
@@ -551,12 +560,13 @@ public abstract class AbstractBrailleTranslator extends AbstractTransform implem
 							lastCharIsSpace = true;
 							break;
 						default:
-							if (bufSize >= limit) break loop;
+							if (bufSize >= limit) return;
 							charBuffer.append(next);
 							bufSize ++;
 							wrapInfo.add(NO_SOFT_WRAP);
 							lastCharIsSpace = false; }
-						inputBuffer.next(); }
+						inputBuffer.next();
+					}
 				}
 				
 				/**

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/AbstractHyphenator.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/AbstractHyphenator.java
@@ -1,8 +1,16 @@
 package org.daisy.pipeline.braille.common;
 
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
+import com.google.common.base.Splitter;
+import static com.google.common.collect.Iterables.toArray;
+
+import static org.daisy.pipeline.braille.common.util.Strings.extractHyphens;
+import static org.daisy.pipeline.braille.common.util.Strings.insertHyphens;
+import static org.daisy.pipeline.braille.common.util.Strings.join;
 import static org.daisy.pipeline.braille.common.util.Strings.splitInclDelimiter;
+import static org.daisy.pipeline.braille.common.util.Tuple2;
 
 public abstract class AbstractHyphenator extends AbstractTransform implements Hyphenator {
 	
@@ -19,6 +27,110 @@ public abstract class AbstractHyphenator extends AbstractTransform implements Hy
 	/* ================== */
 	
 	public static abstract class util {
+		
+		private final static Pattern ON_SPACE_SPLITTER = Pattern.compile("\\s+");
+
+		public static abstract class DefaultFullHyphenator implements FullHyphenator {
+
+			/**
+			 * Whether the length of the array returned by {@link
+			 * #getHyphenationOpportunities()} is based on the number of code points in
+			 * the input or the number of characters.
+			 */
+			protected abstract boolean isCodePointAware();
+
+			/**
+			 * Get hyphenation opportunities as a byte array (1 = SHY, 2 = ZWSP)
+			 *
+			 * @param textWithoutHyphens text that does not contain SHY and ZWSP characters (and from
+			 *                           which no SHY and ZWSP characters were extracted either)
+			 */
+			protected abstract byte[] getHyphenationOpportunities(String textWithoutHyphens) throws NonStandardHyphenationException;
+
+			private final static char SHY = '\u00AD';
+			private final static char ZWSP = '\u200B';
+			private final static char US = '\u001F';
+			private final static Splitter SEGMENT_SPLITTER = Splitter.on(US);
+
+			@Override
+			public String transform(String text) throws NonStandardHyphenationException {
+				if (text.length() == 0)
+					return text;
+				Tuple2<String,byte[]> t = extractHyphens(text, isCodePointAware(), SHY, ZWSP);
+				if (t._1.length() == 0)
+					return text;
+				return insertHyphens(t._1, transform(t._2, t._1), isCodePointAware(), SHY, ZWSP);
+			}
+
+			@Override
+			public String[] transform(String text[]) throws NonStandardHyphenationException {
+				Tuple2<String,byte[]> t = extractHyphens(join(text, US), isCodePointAware(), SHY, ZWSP);
+				String[] unhyphenated = toArray(SEGMENT_SPLITTER.split(t._1), String.class);
+				t = extractHyphens(t._2, t._1, isCodePointAware(), null, null, US);
+				String _text = t._1;
+				// This byte array is used not only to track the hyphen
+				// positions but also the segment boundaries.
+				byte[] positions = t._2;
+				positions = transform(positions, _text);
+				_text = insertHyphens(_text, positions, isCodePointAware(), SHY, ZWSP, US);
+				if (text.length == 1)
+					return new String[]{_text};
+				else {
+					String[] rv = new String[text.length];
+					int i = 0;
+					for (String s : SEGMENT_SPLITTER.split(_text)) {
+						while (unhyphenated[i].length() == 0)
+							rv[i++] = "";
+						rv[i++] = s; }
+					while(i < text.length)
+						rv[i++] = "";
+					return rv; }
+			}
+
+			/**
+			 * @param manualHyphens      SHY and ZWSP characters that were extracted from the original
+			 *                           text, which resulted in <code>textWithoutHyphens</code>
+			 * @param textWithoutHyphens text without SHY and ZWSP characters
+			 */
+			protected byte[] transform(byte[] manualHyphens, String textWithoutHyphens) throws NonStandardHyphenationException {
+				if (textWithoutHyphens.length() == 0)
+					return manualHyphens;
+				boolean hasManualHyphens = false; {
+					if (manualHyphens != null)
+						for (byte b : manualHyphens)
+							if (b == (byte)1 || b == (byte)2) {
+								hasManualHyphens = true;
+								break; }}
+				if (hasManualHyphens) {
+					// input contains SHY or ZWSP; hyphenate only the words (sequences of non white space)
+					// without SHY or ZWSP
+					byte[] hyphens = Arrays.copyOf(manualHyphens, manualHyphens.length);
+					boolean word = true;
+					int pos = 0;
+					for (String segment : splitInclDelimiter(textWithoutHyphens, ON_SPACE_SPLITTER)) {
+						int len = isCodePointAware()
+							? segment.codePointCount(0, segment.length())
+							: segment.length();
+						if (word && len > 0) {
+							boolean wordHasManualHyphens = false; {
+								for (int k = 0; k < len - 1; k++)
+									if (hyphens[pos + k] != 0) {
+										wordHasManualHyphens = true;
+										break; }}
+							if (!wordHasManualHyphens) {
+								byte[] wordHyphens = getHyphenationOpportunities(segment);
+								for (int k = 0; k < len - 1; k++)
+									hyphens[pos + k] |= wordHyphens[k];
+							}
+						}
+						pos += len;
+						word = !word;
+					}
+					return hyphens;
+				} else
+					return getHyphenationOpportunities(textWithoutHyphens);
+			}
+		}
 		
 		// TODO: caching?
 		public static abstract class DefaultLineBreaker implements LineBreaker {
@@ -45,8 +157,6 @@ public abstract class AbstractHyphenator extends AbstractTransform implements Hy
 					return firstLine() + "=" + secondLine();
 				}
 			}
-			
-			private final static Pattern ON_SPACE_SPLITTER = Pattern.compile("\\s+");
 			
 			public LineIterator transform(final String text) {
 				

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/BrailleTranslator.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/BrailleTranslator.java
@@ -1,6 +1,7 @@
 package org.daisy.pipeline.braille.common;
 
 import org.daisy.dotify.api.translator.BrailleTranslatorResult;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 public interface BrailleTranslator extends Transform {
 	

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/CompoundBrailleTranslator.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/CompoundBrailleTranslator.java
@@ -14,6 +14,7 @@ import org.daisy.braille.css.BrailleCSSProperty.Hyphens;
 import org.daisy.braille.css.BrailleCSSProperty.TextTransform;
 import org.daisy.dotify.api.translator.UnsupportedMetricException;
 import org.daisy.pipeline.braille.common.Hyphenator.NonStandardHyphenationException;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 import com.google.common.collect.Iterables;
 

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/CompoundBrailleTranslator.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/CompoundBrailleTranslator.java
@@ -223,6 +223,11 @@ public class CompoundBrailleTranslator extends AbstractBrailleTranslator {
 		return lineBreakingFromStyledText;
 	}
 
+	/*
+	 * Note that this function can not be used to concatenate any LineIterator. It is assumed that
+	 * the LineIterator are translations of consecutive segments of the same string, where each
+	 * translation has taken into account the whole context.
+	 */
 	static BrailleTranslator.LineIterator concatLineIterators(List<BrailleTranslator.LineIterator> iterators) {
 		if (iterators.size() == 0)
 			return new BrailleTranslator.LineIterator() {

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/Hyphenator.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/Hyphenator.java
@@ -1,5 +1,7 @@
 package org.daisy.pipeline.braille.common;
 
+import org.daisy.pipeline.braille.css.CSSStyledText;
+
 /**
  * Hyphenation means morphological breaking within <em>words</em>. However this class is
  * not only responsible for providing hyphenation opportunities, but all soft wrap
@@ -30,8 +32,7 @@ public interface Hyphenator extends Transform {
 	
 	public interface FullHyphenator {
 		
-		public String transform(String text) throws NonStandardHyphenationException;
-		public String[] transform(String[] text) throws NonStandardHyphenationException;
+		public Iterable<CSSStyledText> transform(Iterable<CSSStyledText> text) throws NonStandardHyphenationException;
 		
 	}
 	

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/Hyphenator.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/Hyphenator.java
@@ -1,23 +1,26 @@
 package org.daisy.pipeline.braille.common;
 
 /**
- * Hyphenating means breaking within words.
+ * Hyphenation means morphological breaking within <em>words</em>. However this class is
+ * not only responsible for providing hyphenation opportunities, but all soft wrap
+ * opportunities (including but not restricted to those defined by the Unicode line
+ * breaking rules [UAX14]).
  */
 public interface Hyphenator extends Transform {
 	
 	/**
-	 * Hyphenate by inserting soft hyphens and zero width spaces in order to indicate all
-	 * the break opportunities within words. Don't add new break opportunities to words
-	 * that already have a soft hyphen or zero width space it them. Apart from the
-	 * insertion of these special characters no other transformations are allowed. This
-	 * means that non-standard hyphenation can not be supported through this interface.
+	 * Indicate all soft wrap opportunities by inserting soft hyphens and zero width
+	 * spaces. Don't add new soft wrap opportunities to words that already have a soft
+	 * hyphen or zero width space in them. Soft wrap opportunities at white space may also
+	 * be omitted. Apart from the insertion of these special characters no other
+	 * transformations are allowed. This means that non-standard hyphenation can not be
+	 * supported through this interface.
 	 */
 	public FullHyphenator asFullHyphenator() throws UnsupportedOperationException;
 	
 	/**
-	 * Hyphenate by breaking an input into lines of a preferred and maximal
-	 * length. Transformations such as non-standard hyphenation are
-	 * allowed.
+	 * Break the input into lines of a preferred and maximal length. Transformations such
+	 * as non-standard hyphenation are allowed.
 	 */
 	public LineBreaker asLineBreaker() throws UnsupportedOperationException;
 	

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/Memoizing.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/Memoizing.java
@@ -1,6 +1,5 @@
 package org.daisy.pipeline.braille.common;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,43 +32,6 @@ public interface Memoizing<K,V> extends Function<K,V> {
 					cache.put(key, value);
 					return value; }
 				return null;
-			}
-			
-			public void invalidateCache() {
-				cache.clear();
-			}
-		}
-		
-		public static abstract class CloningMemoizing<K,V extends Cloneable> implements Memoizing<K,V> {
-			
-			private final Map<K,V> cache = new HashMap<K,V>();
-			
-			/**
-			 * @param key must not be mutated.
-			 */
-			protected abstract V _apply(K key);
-	
-			public final V apply(K key) {
-				V value;
-				if (cache.containsKey(key))
-					value = cache.get(key);
-				else {
-					value = _apply(key);
-					if (value != null)
-						cache.put(key, value); }
-				if (value == null)
-					return null;
-				else {
-					try {
-						return (V)value.getClass().getMethod("clone").invoke(value); }
-					catch (IllegalAccessException
-					       | IllegalArgumentException
-					       | InvocationTargetException
-					       | NoSuchMethodException
-					       | SecurityException e) {
-						throw new RuntimeException("Could not invoke clone() method", e);
-					}
-				}
 			}
 			
 			public void invalidateCache() {

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/TextTransformParser.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/TextTransformParser.java
@@ -73,10 +73,16 @@ public class TextTransformParser {
 						}
 						String value;
 						if (d.get(0) instanceof TermURI) {
-							URL cssBase = ((TermURI)d.get(0)).getBase(); // this is always null because the source is a string
-							value = URLs.resolve(cssBase != null ? URLs.asURI(cssBase) : baseURI,
-							                     URLs.asURI(((TermURI)d.get(0)).getValue()))
-							            .toASCIIString();
+							URI uri = URLs.asURI(((TermURI)d.get(0)).getValue());
+							if (!uri.isAbsolute() && !uri.getSchemeSpecificPart().startsWith("/")) {
+								// relative URI
+								URI cssBase; {
+									URL b = ((TermURI)d.get(0)).getBase(); // this is always null because the style is provided as a string
+									cssBase = b != null ? URLs.asURI(b) : baseURI;
+								}
+								uri = URLs.resolve(cssBase, uri);
+							}
+							value = uri.toASCIIString();
 						} else {
 							if (d.get(0) instanceof TermInteger)
 								value = "" + ((TermInteger)d.get(0)).getIntValue();

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/UnityBrailleTranslator.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/UnityBrailleTranslator.java
@@ -15,10 +15,9 @@ import org.daisy.braille.css.BrailleCSSProperty.BrailleCharset;
 import org.daisy.braille.css.BrailleCSSProperty.Hyphens;
 import org.daisy.braille.css.BrailleCSSProperty.TextTransform;
 import org.daisy.braille.css.BrailleCSSProperty.WhiteSpace;
-import org.daisy.pipeline.braille.common.AbstractBrailleTranslator;
 import org.daisy.pipeline.braille.common.AbstractBrailleTranslator.util.DefaultLineBreaker;
-import org.daisy.pipeline.braille.common.CSSStyledText;
 import static org.daisy.pipeline.braille.common.util.Strings.splitInclDelimiter;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/saxon/impl/TextTransformDefinition.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/saxon/impl/TextTransformDefinition.java
@@ -20,9 +20,9 @@ import net.sf.saxon.value.StringValue;
 import org.daisy.pipeline.braille.common.BrailleTranslator;
 import org.daisy.pipeline.braille.common.BrailleTranslator.FromStyledTextToBraille;
 import org.daisy.pipeline.braille.common.BrailleTranslatorRegistry;
-import org.daisy.pipeline.braille.common.CSSStyledText;
 import org.daisy.pipeline.braille.common.Query;
 import static org.daisy.pipeline.braille.common.Query.util.query;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;

--- a/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/util.java
+++ b/braille/braille-common/src/main/java/org/daisy/pipeline/braille/common/util.java
@@ -277,6 +277,10 @@ public abstract class util {
 				protected Iterator<T> _iterator() {
 					return iterable.iterator();
 				}
+				@Override
+				public String toString() {
+					return iterable.toString();
+				}
 			};
 		}
 		

--- a/braille/braille-common/src/test/java/UppercaseTransform.java
+++ b/braille/braille-common/src/test/java/UppercaseTransform.java
@@ -14,9 +14,9 @@ import org.daisy.pipeline.braille.common.AbstractBrailleTranslator;
 import org.daisy.pipeline.braille.common.BrailleTranslator;
 import org.daisy.pipeline.braille.common.BrailleTranslatorProvider;
 import org.daisy.pipeline.braille.common.calabash.CxEvalBasedTransformer;
-import org.daisy.pipeline.braille.common.CSSStyledText;
 import org.daisy.pipeline.braille.common.Query;
 import org.daisy.pipeline.braille.common.TransformProvider;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 import org.ops4j.pax.exam.util.PathUtils;
 

--- a/braille/braille-common/src/test/java/org/daisy/pipeline/braille/common/DefaultLineBreakerTest.java
+++ b/braille/braille-common/src/test/java/org/daisy/pipeline/braille/common/DefaultLineBreakerTest.java
@@ -1,10 +1,12 @@
 package org.daisy.pipeline.braille.common;
 
 import java.util.ArrayList;
+import static java.util.Collections.singleton;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.daisy.braille.css.SimpleInlineStyle;
 import static org.daisy.pipeline.braille.common.util.Strings.extractHyphens;
 import org.daisy.pipeline.braille.css.CSSStyledText;
 
@@ -227,6 +229,7 @@ public class DefaultLineBreakerTest {
 		}
 		
 		private final static Pattern WORD_SPLITTER = Pattern.compile("[\\x20\t\\n\\r\\u2800\\xA0]+");
+		private final static SimpleInlineStyle HYPHENS_AUTO = new SimpleInlineStyle("hyphens: auto");
 		
 		private final LineBreakingFromStyledText lineBreaker = new AbstractBrailleTranslator.util.DefaultLineBreaker(' ', '-', null) {
 			protected BrailleStream translateAndHyphenate(final Iterable<CSSStyledText> styledText, int from, int to) {
@@ -254,7 +257,8 @@ public class DefaultLineBreakerTest {
 							pos = end; }
 						else {
 							try {
-								next = hyphenator.asFullHyphenator().transform(text.substring(pos));
+								next = hyphenator.asFullHyphenator().transform(
+									singleton(new CSSStyledText(text.substring(pos), HYPHENS_AUTO))).iterator().next().getText();
 								pos = end; }
 							catch (Exception e) {
 								Matcher m = WORD_SPLITTER.matcher(text.substring(pos));

--- a/braille/braille-common/src/test/java/org/daisy/pipeline/braille/common/DefaultLineBreakerTest.java
+++ b/braille/braille-common/src/test/java/org/daisy/pipeline/braille/common/DefaultLineBreakerTest.java
@@ -5,15 +5,16 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
 import org.daisy.pipeline.braille.common.AbstractBrailleTranslator;
 import org.daisy.pipeline.braille.common.AbstractHyphenator;
 import org.daisy.pipeline.braille.common.CSSStyledText;
 import org.daisy.pipeline.braille.common.BrailleTranslator;
 import org.daisy.pipeline.braille.common.Hyphenator;
+import static org.daisy.pipeline.braille.common.util.Strings.extractHyphens;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class DefaultLineBreakerTest {
 	
@@ -187,18 +188,18 @@ public class DefaultLineBreakerTest {
 			return fullHyphenator;
 		}
 		
-		private static final FullHyphenator fullHyphenator = new FullHyphenator() {
-			public String transform(String text) {
+		private static final FullHyphenator fullHyphenator = new AbstractHyphenator.util.DefaultFullHyphenator() {
+
+			private final static char SHY = '\u00AD';
+			private final static char ZWSP = '\u200B';
+
+			protected boolean isCodePointAware() { return false; }
+		
+			protected byte[] getHyphenationOpportunities(String text) throws RuntimeException {
 				if (text.contains("busstopp"))
 					throw new RuntimeException("text contains non-standard break points");
 				else
-					return text;
-			}
-			public String[] transform(String[] text) {
-				String[] r = new String[text.length];
-				for (int i = 0; i < r.length; i++)
-					r[i] = transform(text[i]);
-				return r;
+					return extractHyphens(text, false, SHY, ZWSP)._2;
 			}
 		};
 		

--- a/braille/braille-common/src/test/java/org/daisy/pipeline/braille/common/DefaultLineBreakerTest.java
+++ b/braille/braille-common/src/test/java/org/daisy/pipeline/braille/common/DefaultLineBreakerTest.java
@@ -5,12 +5,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.daisy.pipeline.braille.common.AbstractBrailleTranslator;
-import org.daisy.pipeline.braille.common.AbstractHyphenator;
-import org.daisy.pipeline.braille.common.CSSStyledText;
-import org.daisy.pipeline.braille.common.BrailleTranslator;
-import org.daisy.pipeline.braille.common.Hyphenator;
 import static org.daisy.pipeline.braille.common.util.Strings.extractHyphens;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;

--- a/braille/braille-common/src/test/java/org/daisy/pipeline/braille/common/DefaultLineBreakerTest.java
+++ b/braille/braille-common/src/test/java/org/daisy/pipeline/braille/common/DefaultLineBreakerTest.java
@@ -22,8 +22,9 @@ public class DefaultLineBreakerTest {
 		TestHyphenator hyphenator = new TestHyphenator();
 		TestTranslator translator = new TestTranslator(hyphenator);
 		assertEquals(
-			"BUSS\n" +
-			"TOPP",
+			"BUS\n" +
+			"STOP\n" +
+			"P",
 			fillLines(translator.lineBreakingFromStyledText().transform(text("busstopp")), 4));
 		assertEquals(
 			"BUSS-\n" +

--- a/braille/braille-css-utils/pom.xml
+++ b/braille/braille-css-utils/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.daisy.pipeline.modules.braille</groupId>
   <artifactId>braille-css-utils</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: braille-css-utils</name>

--- a/braille/braille-css-utils/src/main/java/org/daisy/pipeline/braille/css/CSSStyledText.java
+++ b/braille/braille-css-utils/src/main/java/org/daisy/pipeline/braille/css/CSSStyledText.java
@@ -85,7 +85,7 @@ public class CSSStyledText implements Cloneable {
 	}
 	
 	@Override
-	public Object clone() {
+	public CSSStyledText clone() {
 		CSSStyledText clone; {
 			try {
 				clone = (CSSStyledText)super.clone();
@@ -108,6 +108,47 @@ public class CSSStyledText implements Cloneable {
 		return s;
 	}
 
+	@Override
+	public boolean equals(Object other) {
+		if (this == other)
+			return true;
+		if (!(other instanceof CSSStyledText))
+			return false;
+		CSSStyledText that = (CSSStyledText)other;
+		if (this.text != null) {
+			if (that.text == null)
+				return false;
+			if (!this.text.equals(that.text))
+				return false;
+		} else if (that.text != null)
+			return false;
+		if (this.textAttributes != null && !this.textAttributes.isEmpty()) {
+			if (that.textAttributes == null || that.textAttributes.isEmpty())
+				return false;
+			if (!this.textAttributes.equals(that.textAttributes))
+				return false;
+		} else if (that.textAttributes != null && !that.textAttributes.isEmpty())
+			return false;
+		if (this.style != null && this.style.properties != null && !this.style.properties.isEmpty()) {
+			if (that.style == null || that.style.properties == null || that.style.properties.isEmpty())
+				return false;
+			if (!this.style.equals(that.style))
+				return false;
+		} else if (that.style != null && that.style.properties != null && !that.style.properties.isEmpty())
+			return false;
+		return true;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int hash = 1;
+		hash = prime * hash + (text == null ? 0 : text.hashCode());
+		hash = prime * hash + (textAttributes == null ? 0 : textAttributes.hashCode());
+		hash = prime * hash + (style == null ? 0 : style.hashCode());
+		return hash;
+	}
+
 	private static class Style implements Cloneable {
 
 		SimpleInlineStyle properties;
@@ -128,6 +169,32 @@ public class CSSStyledText implements Cloneable {
 			return clone;
 		}
 
+		@Override
+		// FIXME: don't ignore text-transform defs
+		public boolean equals(Object other) {
+			if (this == other)
+				return true;
+			if (!(other instanceof Style))
+				return false;
+			Style that = (Style)other;
+			if (this.properties != null) {
+				if (that.properties == null)
+					return false;
+				if (!this.properties.equals(that.properties))
+					return false;
+			} else if (that.properties != null)
+				return false;
+			return true;
+		}
+		
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int hash = 1;
+			hash = prime * hash + (properties == null ? 0 : properties.hashCode());
+			return hash;
+		}
+		
 		public static Style parse(String style) {
 			InlineStyle inlineStyle = new InlineStyle(style);
 			Style s = new Style();

--- a/braille/braille-css-utils/src/main/java/org/daisy/pipeline/braille/css/impl/BrailleCssSerializer.java
+++ b/braille/braille-css-utils/src/main/java/org/daisy/pipeline/braille/css/impl/BrailleCssSerializer.java
@@ -1,5 +1,6 @@
 package org.daisy.pipeline.braille.css.impl;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -77,12 +78,11 @@ public final class BrailleCssSerializer {
 			Object val = pair.getValue();
 			return "" + pair.getKey() + " " + (val instanceof Term ? toString((Term<?>)val) : val.toString()); }
 		else if (term instanceof TermURI) {
-			TermURI uri = (TermURI)term;
-			return "url(\""
-				+ (uri.getBase() == null
-					? URLs.asURI(uri.getValue())
-					: URLs.resolve(URLs.asURI(uri.getBase()), URLs.asURI(uri.getValue())))
-				+ "\")"; }
+			TermURI termURI = (TermURI)term;
+			URI uri = URLs.asURI(termURI.getValue());
+			if (termURI.getBase() != null)
+				uri = URLs.resolve(URLs.asURI(termURI.getBase()), uri);
+			return "url(\"" + uri + "\")"; }
 		else if (term instanceof TermString) {
 			TermString string = (TermString)term;
 			return "'" + string.getValue().replaceAll("\n", "\\\\A ").replaceAll("'", "\\\\27 ") + "'"; }

--- a/braille/dotify-utils/src/main/java/org/daisy/pipeline/braille/dotify/impl/BrailleTranslatorFactoryServiceImpl.java
+++ b/braille/dotify-utils/src/main/java/org/daisy/pipeline/braille/dotify/impl/BrailleTranslatorFactoryServiceImpl.java
@@ -31,11 +31,11 @@ import org.daisy.dotify.api.translator.TranslatorSpecification;
 
 import org.daisy.pipeline.braille.common.AbstractBrailleTranslator.util.DefaultLineBreaker;
 import org.daisy.pipeline.braille.common.BrailleTranslatorRegistry;
-import org.daisy.pipeline.braille.common.CSSStyledText;
 import org.daisy.pipeline.braille.common.Query;
 import static org.daisy.pipeline.braille.common.Query.util.mutableQuery;
 import static org.daisy.pipeline.braille.common.Query.util.query;
 import static org.daisy.pipeline.braille.common.Query.util.QUERY;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;

--- a/braille/dotify-utils/src/main/java/org/daisy/pipeline/braille/dotify/impl/CounterHandlingBrailleTranslator.java
+++ b/braille/dotify-utils/src/main/java/org/daisy/pipeline/braille/dotify/impl/CounterHandlingBrailleTranslator.java
@@ -14,9 +14,8 @@ import org.daisy.braille.css.BrailleCSSProperty.TextTransform;
 import org.daisy.pipeline.braille.common.AbstractBrailleTranslator;
 import org.daisy.pipeline.braille.common.BrailleTranslator;
 import org.daisy.pipeline.braille.common.BrailleTranslator.LineBreakingFromStyledText;
-import org.daisy.pipeline.braille.common.CSSStyledText;
-
 import org.daisy.pipeline.braille.css.CounterStyle;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 /**
  * {@link BrailleTranslator} that handles the <code>text-transform</code> value

--- a/braille/dotify-utils/src/main/java/org/daisy/pipeline/braille/dotify/impl/DotifyTranslatorImpl.java
+++ b/braille/dotify-utils/src/main/java/org/daisy/pipeline/braille/dotify/impl/DotifyTranslatorImpl.java
@@ -114,13 +114,17 @@ public class DotifyTranslatorImpl extends AbstractBrailleTranslator implements D
 		}
 	};
 	
+	private final static SimpleInlineStyle HYPHENS_AUTO = new SimpleInlineStyle("hyphens: auto");
+	
 	private String transform(String text, boolean hyphenate) {
 		if (hyphenate && !hyphenating)
-			throw new RuntimeException("'hyphens:auto' is not supported");
+			throw new RuntimeException("'hyphens: auto' is not supported");
 		try {
-			if (hyphenate && externalHyphenator != null)
-				return filter.filter(Translatable.text(externalHyphenator.asFullHyphenator().transform(text)).hyphenate(false).build());
-			else
+			if (hyphenate && externalHyphenator != null) {
+				String hyphenatedText = externalHyphenator.asFullHyphenator().transform(
+					Collections.singleton(new CSSStyledText(text, HYPHENS_AUTO))).iterator().next().getText();
+				return filter.filter(Translatable.text(hyphenatedText).hyphenate(false).build());
+			} else
 				return filter.filter(Translatable.text(text).hyphenate(hyphenate).build()); }
 		catch (TranslationException e) {
 			throw new RuntimeException(e); }

--- a/braille/dotify-utils/src/main/java/org/daisy/pipeline/braille/dotify/impl/DotifyTranslatorImpl.java
+++ b/braille/dotify-utils/src/main/java/org/daisy/pipeline/braille/dotify/impl/DotifyTranslatorImpl.java
@@ -35,7 +35,6 @@ import static org.daisy.pipeline.braille.common.AbstractTransformProvider.util.I
 import static org.daisy.pipeline.braille.common.AbstractTransformProvider.util.logCreate;
 import static org.daisy.pipeline.braille.common.AbstractTransformProvider.util.logSelect;
 import org.daisy.pipeline.braille.common.BrailleTranslatorProvider;
-import org.daisy.pipeline.braille.common.CSSStyledText;
 import org.daisy.pipeline.braille.common.Hyphenator;
 import org.daisy.pipeline.braille.common.HyphenatorRegistry;
 import org.daisy.pipeline.braille.common.Query;
@@ -46,6 +45,7 @@ import org.daisy.pipeline.braille.common.TransformProvider;
 import static org.daisy.pipeline.braille.common.TransformProvider.util.varyLocale;
 import static org.daisy.pipeline.braille.common.util.Locales.parseLocale;
 import static org.daisy.pipeline.braille.common.util.Strings.join;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 import org.daisy.pipeline.braille.dotify.DotifyTranslator;
 
 import org.osgi.framework.FrameworkUtil;

--- a/braille/dotify-utils/src/test/java/DotifyCoreTest.java
+++ b/braille/dotify-utils/src/test/java/DotifyCoreTest.java
@@ -5,9 +5,9 @@ import javax.inject.Inject;
 
 import org.daisy.braille.css.SimpleInlineStyle;
 
-import org.daisy.pipeline.braille.common.CSSStyledText;
 import static org.daisy.pipeline.braille.common.Query.util.query;
 import org.daisy.pipeline.braille.dotify.DotifyTranslator;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 import org.daisy.pipeline.junit.AbstractTest;
 
 import org.junit.Test;

--- a/braille/dotify-utils/src/test/java/NumberBrailleTranslator.java
+++ b/braille/dotify-utils/src/test/java/NumberBrailleTranslator.java
@@ -14,11 +14,11 @@ import org.daisy.braille.css.SimpleInlineStyle;
 
 import org.daisy.pipeline.braille.common.AbstractBrailleTranslator;
 import org.daisy.pipeline.braille.common.BrailleTranslatorProvider;
-import org.daisy.pipeline.braille.common.CSSStyledText;
 import org.daisy.pipeline.braille.common.Query;
 import org.daisy.pipeline.braille.common.Query.MutableQuery;
 import static org.daisy.pipeline.braille.common.Query.util.mutableQuery;
 import org.daisy.pipeline.braille.common.TransformProvider;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 import org.osgi.service.component.annotations.Component;
 

--- a/braille/dotify-utils/src/test/xprocspec/test_format.xprocspec
+++ b/braille/dotify-utils/src/test/xprocspec/test_format.xprocspec
@@ -17,6 +17,7 @@
       <p:output port="obfl" sequence="false">
         <p:pipe step="obfl-final" port="result"/>
       </p:output>
+      <p:option name="document-locale" select="'und'"/>
       <p:option name="text-transform" select="'(input:braille)'"/>
       <p:option name="braille-charset" select="''"/>
       <p:option name="skip-margin-top-of-page" select="'false'"/>
@@ -25,7 +26,8 @@
       <p:import href="../../main/resources/xml/obfl-normalize-space.xpl"/>
       <p:import href="http://www.daisy.org/pipeline/modules/braille/dotify-utils/library.xpl"/>
       <pxi:css-to-obfl name="obfl" px:message="css-to-obfl" px:progress=".89"
-                       duplex="true" document-locale="und">
+                       duplex="true">
+        <p:with-option name="document-locale" select="$document-locale"/>
         <p:with-option name="text-transform" select="$text-transform"/>
         <p:with-option name="braille-charset" select="$braille-charset"/>
         <p:with-option name="skip-margin-top-of-page" select="$skip-margin-top-of-page"/>
@@ -2749,7 +2751,7 @@
   
   <x:scenario label="test_25">
     <x:documentation>
-      Tests (pre-)hyphenation.
+      Tests pre-hyphenated text.
     </x:documentation>
     <x:call step="dotify:format">
       <x:input port="source">
@@ -3978,8 +3980,8 @@
   
   <x:scenario label="test_41">
     <x:documentation>
-      Tests hyphens:none, text-transform. hyphens:none is currently handled in XSLT (not in
-      Dotify). text-transform is handled in Dotify.
+      Tests hyphens:none and text-transform. hyphens:none is currently handled with a style
+      element. text-transform is handled with a style element and/or translate attributes.
     </x:documentation>
     <x:call step="dotify:format">
       <x:input port="source">
@@ -16842,6 +16844,142 @@
     </x:expect>
   </x:scenario>
   
+   <x:scenario label="test_141">
+    <x:documentation>
+      Tests hyphenation during formatting.
+    </x:documentation>
+    <x:call step="dotify:format">
+      <x:input port="source">
+        <x:document type="inline">
+          <doc style="@page { size: 12 25; }">
+            <p style="display: block; hyphens: none">
+              xxxxxx foo-bar xxxxxx
+            </p>
+            <p style="display: block; hyphens: manual">
+              xxxxxx foo-bar xxxxxx
+            </p>
+            <p style="display: block; hyphens: auto">
+              xxxxxx foo-bar xxxxxx
+            </p>
+            <p style="display: block; hyphens: none">
+              xxxxxx foo­bar xxxxxx
+            </p>
+            <p style="display: block; hyphens: manual">
+              xxxxxx foo­bar xxxxxx
+            </p>
+            <p style="display: block; hyphens: auto">
+              xxxxxx foo­bar xxxxxx
+            </p>
+            <p style="display: block; hyphens: none">
+              xxxxxx foobar xxxxxx
+            </p>
+            <p style="display: block; hyphens: manual">
+              xxxxxx foobar xxxxxx
+            </p>
+            <p style="display: block; hyphens: auto">
+              xxxxxx foobar xxxxxx
+            </p>
+          </doc>
+        </x:document>
+      </x:input>
+      <x:option name="document-locale" select="'en'"/>
+      <x:option name="text-transform" select="'(system:ueb)(grade:1)'"/>
+    </x:call>
+    <x:context label="obfl">
+      <x:document type="port" port="obfl"/>
+    </x:context>
+    <x:expect label="obfl" type="custom" href="http://www.daisy.org/pipeline/modules/braille/obfl-utils/library.xpl" step="x:obfl-compare">
+      <x:document type="inline">
+        <obfl xmlns="http://www.daisy.org/ns/2011/obfl" version="2011-1" xml:lang="en" hyphenate="false">
+          <meta xmlns:dp2="http://www.daisy.org/ns/pipeline/">
+            <dp2:style-type>text/css</dp2:style-type>
+          </meta>
+          <layout-master name="a" page-width="12" page-height="25" duplex="true">
+            <default-template>
+              <header/>
+              <footer/>
+            </default-template>
+          </layout-master>
+          <sequence master="a">
+            <block>
+              <style name="hyphens: none">xxxxxx foo-bar xxxxxx</style>
+            </block>
+            <block>
+              xxxxxx foo-bar xxxxxx
+            </block>
+            <block hyphenate="true">
+              xxxxxx foo-bar xxxxxx
+            </block>
+            <block>
+              <style name="hyphens: none">xxxxxx foo­bar xxxxxx</style>
+            </block>
+            <block>
+              xxxxxx foo­bar xxxxxx
+            </block>
+            <block hyphenate="true">
+              xxxxxx foo­bar xxxxxx
+            </block>
+            <block>
+              <style name="hyphens: none">xxxxxx foobar xxxxxx</style>
+            </block>
+            <block>
+              xxxxxx foobar xxxxxx
+            </block>
+            <block hyphenate="true">
+              xxxxxx foobar xxxxxx
+            </block>
+          </sequence>
+        </obfl>
+      </x:document>
+    </x:expect>
+    <x:context label="pef">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="pef" type="custom" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl" step="x:pef-compare">
+      <x:document type="inline">
+        <pef xmlns="http://www.daisy.org/ns/2008/pef" version="2008-1">
+          <head xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <meta>
+              <dc:format>application/x-pef+xml</dc:format>
+            </meta>
+          </head>
+          <body>
+            <volume cols="12" rows="25" rowgap="0" duplex="true">
+              <section>
+                <page>
+                  <!-- foo-bar -->
+                  <row>⠭⠭⠭⠭⠭⠭⠀⠋⠕⠕⠤</row>
+                  <row>⠃⠁⠗⠀⠭⠭⠭⠭⠭⠭</row>
+                  <row>⠭⠭⠭⠭⠭⠭⠀⠋⠕⠕⠤</row>
+                  <row>⠃⠁⠗⠀⠭⠭⠭⠭⠭⠭</row>
+                  <row>⠭⠭⠭⠭⠭⠭⠀⠋⠕⠕⠤</row>
+                  <row>⠃⠁⠗⠀⠭⠭⠭⠭⠭⠭</row>
+                  <!-- foo­bar -->
+                  <row>⠭⠭⠭⠭⠭⠭</row>
+                  <row>⠋⠕⠕⠃⠁⠗</row>
+                  <row>⠭⠭⠭⠭⠭⠭</row>
+                  <row>⠭⠭⠭⠭⠭⠭⠀⠋⠕⠕⠤</row>
+                  <row>⠃⠁⠗⠀⠭⠭⠭⠭⠭⠭</row>
+                  <row>⠭⠭⠭⠭⠭⠭⠀⠋⠕⠕⠤</row>
+                  <row>⠃⠁⠗⠀⠭⠭⠭⠭⠭⠭</row>
+                  <!-- foobar -->
+                  <row>⠭⠭⠭⠭⠭⠭</row>
+                  <row>⠋⠕⠕⠃⠁⠗</row>
+                  <row>⠭⠭⠭⠭⠭⠭</row>
+                  <row>⠭⠭⠭⠭⠭⠭</row>
+                  <row>⠋⠕⠕⠃⠁⠗</row>
+                  <row>⠭⠭⠭⠭⠭⠭</row>
+                  <row>⠭⠭⠭⠭⠭⠭⠀⠋⠕⠕⠤</row>
+                  <row>⠃⠁⠗⠀⠭⠭⠭⠭⠭⠭</row>
+                </page>
+              </section>
+            </volume>
+          </body>
+        </pef>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
   <x:scenario label="test_142">
     <x:documentation>
       Tests that content in top margin is trimmed when needed. (Note that if

--- a/braille/libhyphen-utils/pom.xml
+++ b/braille/libhyphen-utils/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.daisy.pipeline.modules.braille</groupId>
   <artifactId>libhyphen-utils</artifactId>
-  <version>3.0.1-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: libhyphen-utils</name>

--- a/braille/libhyphen-utils/src/main/java/org/daisy/pipeline/braille/libhyphen/impl/LibhyphenJnaImpl.java
+++ b/braille/libhyphen-utils/src/main/java/org/daisy/pipeline/braille/libhyphen/impl/LibhyphenJnaImpl.java
@@ -8,12 +8,10 @@ import java.net.URL;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.regex.Pattern;
 
 import ch.sbs.jhyphen.CompilationException;
 import ch.sbs.jhyphen.Hyphen;
@@ -24,11 +22,11 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Splitter;
 import com.google.common.cache.CacheBuilder;
-import static com.google.common.collect.Iterables.toArray;
 import static com.google.common.collect.Iterables.transform;
 
 import org.daisy.common.file.URLs;
 import org.daisy.pipeline.braille.common.AbstractHyphenator;
+import org.daisy.pipeline.braille.common.AbstractHyphenator.util.DefaultFullHyphenator;
 import org.daisy.pipeline.braille.common.AbstractHyphenator.util.DefaultLineBreaker;
 import org.daisy.pipeline.braille.common.AbstractTransformProvider;
 import org.daisy.pipeline.braille.common.AbstractTransformProvider.util.Function;
@@ -47,11 +45,6 @@ import static org.daisy.pipeline.braille.common.Query.util.mutableQuery;
 import static org.daisy.pipeline.braille.common.util.Files.asFile;
 import static org.daisy.pipeline.braille.common.util.Files.isAbsoluteFile;
 import static org.daisy.pipeline.braille.common.util.Locales.parseLocale;
-import static org.daisy.pipeline.braille.common.util.Strings.extractHyphens;
-import static org.daisy.pipeline.braille.common.util.Strings.insertHyphens;
-import static org.daisy.pipeline.braille.common.util.Strings.join;
-import static org.daisy.pipeline.braille.common.util.Strings.splitInclDelimiter;
-import org.daisy.pipeline.braille.common.util.Tuple2;
 import org.daisy.pipeline.braille.common.WithSideEffect;
 import org.daisy.pipeline.braille.libhyphen.LibhyphenHyphenator;
 
@@ -80,9 +73,6 @@ import org.slf4j.LoggerFactory;
 )
 public class LibhyphenJnaImpl extends AbstractTransformProvider<LibhyphenHyphenator>
 	                          implements LibhyphenHyphenator.Provider {
-	
-	private final static char SHY = '\u00AD';
-	private final static char ZWSP = '\u200B';
 	
 	private LibhyphenTableRegistry tableRegistry;
 	
@@ -191,10 +181,6 @@ public class LibhyphenJnaImpl extends AbstractTransformProvider<LibhyphenHyphena
 		}
 	}
 	
-	private final static char US = '\u001F';
-	private final static Splitter SEGMENT_SPLITTER = Splitter.on(US);
-	private final static Pattern ON_SPACE_SPLITTER = Pattern.compile("\\s+");
-	
 	private class LibhyphenHyphenatorImpl extends AbstractHyphenator implements LibhyphenHyphenator {
 		
 		private final URI table;
@@ -214,12 +200,20 @@ public class LibhyphenJnaImpl extends AbstractTransformProvider<LibhyphenHyphena
 			return fullHyphenator;
 		}
 		
-		private final FullHyphenator fullHyphenator = new FullHyphenator() {
-			public String transform(String text) throws NonStandardHyphenationException {
-				return LibhyphenHyphenatorImpl.this.transform(text);
+		private final FullHyphenator fullHyphenator = new DefaultFullHyphenator() {
+			protected boolean isCodePointAware() { return false; }
+			protected byte[] getHyphenationOpportunities(String textWithoutHyphens) throws NonStandardHyphenationException, RuntimeException {
+				try {
+					return hyphenator.hyphenate(textWithoutHyphens);
+				} catch (StandardHyphenationException e) {
+					throw new NonStandardHyphenationException(e);
+				} catch (Exception e) {
+					throw new RuntimeException("Error during libhyphen hyphenation", e);
+				}
 			}
-			public String[] transform(String[] text) throws NonStandardHyphenationException {
-				return LibhyphenHyphenatorImpl.this.transform(text);
+			@Override
+			public String toString() {
+				return LibhyphenHyphenatorImpl.this.toString();
 			}
 		};
 		
@@ -236,94 +230,11 @@ public class LibhyphenJnaImpl extends AbstractTransformProvider<LibhyphenHyphena
 				else
 					return new Break(br.getText(), br.getBreakPosition(), br.hasHyphen());
 			}
+			@Override
+			public String toString() {
+				return LibhyphenHyphenatorImpl.this.toString();
+			}
 		};
-		
-		private String transform(String text) {
-			if (text.length() == 0)
-				return text;
-			try {
-				Tuple2<String,byte[]> t = extractHyphens(text, false, SHY, ZWSP);
-				if (t._1.length() == 0)
-					return text;
-				return insertHyphens(t._1, transform(t._2, t._1), false, SHY, ZWSP); }
-			catch (NonStandardHyphenationException e) {
-				throw e; }
-			catch (Exception e) {
-				throw new RuntimeException("Error during libhyphen hyphenation", e); }
-		}
-		
-		private String[] transform(String[] text) {
-			try {
-				Tuple2<String,byte[]> t = extractHyphens(join(text, US), false, SHY, ZWSP);
-				String[] unhyphenated = toArray(SEGMENT_SPLITTER.split(t._1), String.class);
-				t = extractHyphens(t._2, t._1, false, null, null, US);
-				String _text = t._1;
-				// This byte array is used not only to track the hyphen
-				// positions but also the segment boundaries.
-				byte[] positions = t._2;
-				positions = transform(positions, _text);
-				_text = insertHyphens(_text, positions, false, SHY, ZWSP, US);
-				if (text.length == 1)
-					return new String[]{_text};
-				else {
-					String[] rv = new String[text.length];
-					int i = 0;
-					for (String s : SEGMENT_SPLITTER.split(_text)) {
-						while (unhyphenated[i].length() == 0)
-							rv[i++] = "";
-						rv[i++] = s; }
-					while(i < text.length)
-						rv[i++] = "";
-					return rv; }}
-			catch (NonStandardHyphenationException e) {
-				throw e; }
-			catch (Exception e) {
-				throw new RuntimeException("Error during libhyphen hyphenation", e); }
-		}
-		
-		private byte[] transform(byte[] manualHyphens, String textWithoutManualHyphens) {
-			if (textWithoutManualHyphens.length() == 0)
-				return manualHyphens;
-			boolean hasManualHyphens = false; {
-				if (manualHyphens != null)
-					for (byte b : manualHyphens)
-						if (b == (byte)1 || b == (byte)2) {
-							hasManualHyphens = true;
-							break; }}
-			if (hasManualHyphens) {
-				// input contains SHY or ZWSP; hyphenate only the words without SHY or ZWSP
-				byte[] hyphens = Arrays.copyOf(manualHyphens, manualHyphens.length);
-				boolean word = true;
-				int pos = 0;
-				for (String segment : splitInclDelimiter(textWithoutManualHyphens, ON_SPACE_SPLITTER)) {
-					if (word && segment.length() > 0) {
-						int len = segment.length();
-						boolean wordHasManualHyphens = false; {
-							for (int k = 0; k < len - 1; k++)
-								if (hyphens[pos + k] != 0) {
-									wordHasManualHyphens = true;
-									break; }}
-						if (!wordHasManualHyphens) {
-							try {
-								byte[] wordHyphens = hyphenator.hyphenate(segment);
-								for (int k = 0; k < len - 1; k++)
-									hyphens[pos + k] |= wordHyphens[k];
-							} catch (StandardHyphenationException e) {
-								throw new NonStandardHyphenationException(e);
-							}
-						}
-					}
-					pos += segment.length();
-					word = !word;
-				}
-				return hyphens;
-			} else
-				try {
-					return hyphenator.hyphenate(textWithoutManualHyphens);
-				} catch (StandardHyphenationException e) {
-					throw new NonStandardHyphenationException(e);
-				}
-		}
 		
 		@Override
 		public ToStringHelper toStringHelper() {

--- a/braille/libhyphen-utils/src/test/java/LibhyphenCoreTest.java
+++ b/braille/libhyphen-utils/src/test/java/LibhyphenCoreTest.java
@@ -1,6 +1,8 @@
 import java.io.IOException;
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import javax.inject.Inject;
@@ -9,6 +11,7 @@ import static org.daisy.pipeline.braille.common.Hyphenator.FullHyphenator;
 import static org.daisy.pipeline.braille.common.Hyphenator.LineBreaker;
 import static org.daisy.pipeline.braille.common.Hyphenator.LineIterator;
 import static org.daisy.pipeline.braille.common.Query.util.query;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 import org.daisy.pipeline.braille.libhyphen.LibhyphenHyphenator;
 
@@ -46,9 +49,9 @@ public class LibhyphenCoreTest extends AbstractTest {
 		                                   .get(query("(table:'standard.dic')"))
 		                                   .iterator().next()
 		                                   .asFullHyphenator();
-		assertEquals("foo\u00ADbar", hyphenator.transform("foobar"));
-		assertEquals("foo-\u200Bbar", hyphenator.transform("foo-bar"));
-		assertEquals("foo\u00ADbar foob\u00ADar", hyphenator.transform("foobar foob\u00ADar"));
+		assertEquals(text("foo\u00ADbar"), hyphenator.transform(styledText("foobar", "hyphens: auto")));
+		assertEquals(text("foo-\u200Bbar"), hyphenator.transform(styledText("foo-bar", "hyphens: auto")));
+		assertEquals(text("foo\u00ADbar foob\u00ADar"), hyphenator.transform(styledText("foobar foob\u00ADar", "hyphens: auto")));
 	}
 	
 	@Test(expected=RuntimeException.class)
@@ -57,7 +60,7 @@ public class LibhyphenCoreTest extends AbstractTest {
 		                                   .get(query("(table:'non-standard.dic')"))
 		                                   .iterator().next()
 		                                   .asFullHyphenator();
-		hyphenator.transform("foobar");
+		hyphenator.transform(styledText("foobar", "hyphens: auto"));
 	}
 	
 	@Test
@@ -83,6 +86,28 @@ public class LibhyphenCoreTest extends AbstractTest {
 		assertEquals("foo-\n" +
 		             "bar",
 		             fillLines(hyphenator.transform("foo-bar"), 6, '-'));
+	}
+	
+	private Iterable<CSSStyledText> styledText(String... textAndStyle) {
+		List<CSSStyledText> styledText = new ArrayList<CSSStyledText>();
+		String text = null;
+		boolean textSet = false;
+		for (String s : textAndStyle) {
+			if (textSet)
+				styledText.add(new CSSStyledText(text, s));
+			else
+				text = s;
+			textSet = !textSet; }
+		if (textSet)
+			throw new RuntimeException();
+		return styledText;
+	}
+	
+	private Iterable<CSSStyledText> text(String... text) {
+		List<CSSStyledText> styledText = new ArrayList<CSSStyledText>();
+		for (String t : text)
+			styledText.add(new CSSStyledText(t, ""));
+		return styledText;
 	}
 	
 	private static String fillLines(LineIterator lines, int width, char hyphen) {

--- a/braille/libhyphen-utils/src/test/java/LibhyphenCoreTest.java
+++ b/braille/libhyphen-utils/src/test/java/LibhyphenCoreTest.java
@@ -51,6 +51,7 @@ public class LibhyphenCoreTest extends AbstractTest {
 		                                   .asFullHyphenator();
 		assertEquals(text("foo\u00ADbar"), hyphenator.transform(styledText("foobar", "hyphens: auto")));
 		assertEquals(text("foo-\u200Bbar"), hyphenator.transform(styledText("foo-bar", "hyphens: auto")));
+		assertEquals(text("foo-\u200Bbar"), hyphenator.transform(styledText("foo-bar", "hyphens: none")));
 		assertEquals(text("foo\u00ADbar foob\u00ADar"), hyphenator.transform(styledText("foobar foob\u00ADar", "hyphens: auto")));
 	}
 	

--- a/braille/liblouis-utils/pom.xml
+++ b/braille/liblouis-utils/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.daisy.pipeline.modules.braille</groupId>
   <artifactId>liblouis-utils</artifactId>
-  <version>5.0.3-SNAPSHOT</version>
+  <version>5.1.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: liblouis-utils</name>

--- a/braille/liblouis-utils/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisHyphenatorJnaImplProvider.java
+++ b/braille/liblouis-utils/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisHyphenatorJnaImplProvider.java
@@ -1,20 +1,17 @@
 package org.daisy.pipeline.braille.liblouis.impl;
 
-import java.util.Arrays;
 import java.util.NoSuchElementException;
-import java.util.regex.Pattern;
 
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
-import com.google.common.base.Splitter;
 import static com.google.common.collect.Iterables.filter;
-import static com.google.common.collect.Iterables.toArray;
 import static com.google.common.collect.Iterables.transform;
 
 import org.daisy.pipeline.braille.common.AbstractHyphenator;
+import org.daisy.pipeline.braille.common.AbstractHyphenator.util.DefaultFullHyphenator;
 import org.daisy.pipeline.braille.common.HyphenatorProvider;
 import org.daisy.pipeline.braille.common.Provider;
 import org.daisy.pipeline.braille.common.Query;
@@ -22,11 +19,6 @@ import org.daisy.pipeline.braille.common.Query.MutableQuery;
 import static org.daisy.pipeline.braille.common.Query.util.mutableQuery;
 import org.daisy.pipeline.braille.common.TransformProvider;
 import static org.daisy.pipeline.braille.common.util.Locales.parseLocale;
-import static org.daisy.pipeline.braille.common.util.Strings.extractHyphens;
-import static org.daisy.pipeline.braille.common.util.Strings.insertHyphens;
-import static org.daisy.pipeline.braille.common.util.Strings.join;
-import static org.daisy.pipeline.braille.common.util.Strings.splitInclDelimiter;
-import static org.daisy.pipeline.braille.common.util.Tuple2;
 
 import org.daisy.pipeline.braille.liblouis.LiblouisHyphenator;
 import org.daisy.pipeline.braille.liblouis.LiblouisTable;
@@ -161,95 +153,15 @@ public class LiblouisHyphenatorJnaImplProvider implements LiblouisHyphenator.Pro
 			return fullHyphenator;
 		}
 		
-		private final FullHyphenator fullHyphenator = new FullHyphenator() {
-			public String transform(String text) {
-				return LiblouisHyphenatorImpl.this.transform(text);
-			}
-			public String[] transform(String[] text) {
-				return LiblouisHyphenatorImpl.this.transform(text);
+		private final FullHyphenator fullHyphenator = new DefaultFullHyphenator() {
+			protected boolean isCodePointAware() { return true; }
+			protected byte[] getHyphenationOpportunities(String textWithoutHyphens) throws RuntimeException {
+				try {
+					return translator.hyphenate(textWithoutHyphens); }
+				catch (TranslationException e) {
+					throw new RuntimeException(e); }
 			}
 		};
-		
-		private final static char SHY = '\u00AD';
-		private final static char ZWSP = '\u200B';
-		private final static char US = '\u001F';
-		private final static Splitter SEGMENT_SPLITTER = Splitter.on(US);
-		private final static Pattern ON_SPACE_SPLITTER = Pattern.compile("\\s+");
-		
-		private String transform(String text) {
-			if (text.length() == 0)
-				return text;
-			Tuple2<String,byte[]> t = extractHyphens(text, true, SHY, ZWSP);
-			if (t._1.length() == 0)
-				return text;
-			return insertHyphens(t._1, transform(t._2, t._1), true, SHY, ZWSP);
-		}
-		
-		private String[] transform(String text[]) {
-			Tuple2<String,byte[]> t = extractHyphens(join(text, US), true, SHY, ZWSP);
-			String[] unhyphenated = toArray(SEGMENT_SPLITTER.split(t._1), String.class);
-			t = extractHyphens(t._2, t._1, true, null, null, US);
-			String _text = t._1;
-			// This byte array is used not only to track the hyphen
-			// positions but also the segment boundaries.
-			byte[] positions = t._2;
-			positions = transform(positions, _text);
-			_text = insertHyphens(_text, positions, true, SHY, ZWSP, US);
-			if (text.length == 1)
-				return new String[]{_text};
-			else {
-				String[] rv = new String[text.length];
-				int i = 0;
-				for (String s : SEGMENT_SPLITTER.split(_text)) {
-					while (unhyphenated[i].length() == 0)
-						rv[i++] = "";
-					rv[i++] = s; }
-				while(i < text.length)
-					rv[i++] = "";
-				return rv; }
-		}
-		
-		private byte[] transform(byte[] manualHyphens, String textWithoutManualHyphens) {
-			if (textWithoutManualHyphens.length() == 0)
-				return manualHyphens;
-			boolean hasManualHyphens = false; {
-				if (manualHyphens != null)
-					for (byte b : manualHyphens)
-						if (b == (byte)1 || b == (byte)2) {
-							hasManualHyphens = true;
-							break; }}
-			if (hasManualHyphens) {
-				// input contains SHY or ZWSP; hyphenate only the words without SHY or ZWSP
-				byte[] hyphens = Arrays.copyOf(manualHyphens, manualHyphens.length);
-				boolean word = true;
-				int pos = 0;
-				for (String segment : splitInclDelimiter(textWithoutManualHyphens, ON_SPACE_SPLITTER)) {
-					if (word && segment.length() > 0) {
-						int len = segment.length();
-						boolean wordHasManualHyphens = false; {
-							for (int k = 0; k < len - 1; k++)
-								if (hyphens[pos + k] != 0) {
-									wordHasManualHyphens = true;
-									break; }}
-						if (!wordHasManualHyphens) {
-							byte[] wordHyphens = doHyphenate(segment);
-							for (int k = 0; k < len - 1; k++)
-								hyphens[pos + k] |= wordHyphens[k];
-						}
-					}
-					pos += segment.length();
-					word = !word;
-				}
-				return hyphens;
-			} else
-				return doHyphenate(textWithoutManualHyphens);
-		}
-		
-		private byte[] doHyphenate(String text) {
-			try { return translator.hyphenate(text); }
-			catch (TranslationException e) {
-				throw new RuntimeException(e); }
-		}
 		
 		@Override
 		public ToStringHelper toStringHelper() {

--- a/braille/liblouis-utils/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisTableRegistry.java
+++ b/braille/liblouis-utils/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisTableRegistry.java
@@ -59,8 +59,16 @@ public class LiblouisTableRegistry extends ResourceRegistry<LiblouisTablePath> i
 	@Override
 	public URL resolve(URI resource) {
 		URL resolved = super.resolve(resource);
-		if (resolved == null)
+		if (resolved == null) {
+			if ("volatile-file".equals(resource.getScheme()))
+				try {
+					resource = new URI("file", resource.getSchemeSpecificPart(), resource.getFragment());
+				} catch (Exception e) {
+					// should not happen
+					throw new IllegalStateException(e);
+				}
 			resolved = fileSystem.resolve(resource);
+		}
 		return resolved;
 	}
 	

--- a/braille/liblouis-utils/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisTranslatorJnaImplProvider.java
+++ b/braille/liblouis-utils/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisTranslatorJnaImplProvider.java
@@ -43,6 +43,7 @@ import org.daisy.pipeline.braille.common.AbstractTransformProvider;
 import org.daisy.pipeline.braille.common.AbstractTransformProvider.util.Iterables;
 import org.daisy.pipeline.braille.common.AbstractTransformProvider.util.Function;
 import static org.daisy.pipeline.braille.common.AbstractTransformProvider.util.Iterables.concat;
+import static org.daisy.pipeline.braille.common.AbstractTransformProvider.util.Iterables.memoize;
 import static org.daisy.pipeline.braille.common.AbstractTransformProvider.util.Iterables.transform;
 import static org.daisy.pipeline.braille.common.AbstractTransformProvider.util.logCreate;
 import static org.daisy.pipeline.braille.common.AbstractTransformProvider.util.logSelect;
@@ -198,13 +199,15 @@ public class LiblouisTranslatorJnaImplProvider extends AbstractTransformProvider
 		if (documentLocale != null)
 			q.add("document-locale", documentLocale);
 		q.add("white-space");
-		Iterable<LiblouisTranslator> translators = getSimpleTranslator(
-			q.asImmutable(),
-			documentLocale,
-			hyphenator,
-			handleNonStandardHyphenation);
+		Iterable<LiblouisTranslator> translators = memoize(
+			getSimpleTranslator(
+				q.asImmutable(),
+				documentLocale,
+				hyphenator,
+				handleNonStandardHyphenation));
 		if (translators.apply(null).iterator().hasNext()) {
 			// all translators use the same display table
+			// FIXME: display table has already been computed in the getSimpleTranslator() call above
 			DisplayTable displayTable = tableProvider.get(q).iterator().next().getDisplayTable();
 			BrailleTranslator unityTranslator = new UnityBrailleTranslator(
 				new LiblouisDisplayTableBrailleConverter(displayTable), false);

--- a/braille/liblouis-utils/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisTranslatorJnaImplProvider.java
+++ b/braille/liblouis-utils/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisTranslatorJnaImplProvider.java
@@ -515,7 +515,7 @@ public class LiblouisTranslatorJnaImplProvider extends AbstractTransformProvider
 					if (--to == 0)
 						toChar = joined.length();
 				}
-				return new FullyHyphenatedAndTranslatedString(joined.toString(), fromChar, toChar, '\u2824');
+				return new FullyHyphenatedAndTranslatedString(joined.toString(), fromChar, toChar);
 			}
 			
 			static class BrailleStreamImpl implements BrailleStream {

--- a/braille/liblouis-utils/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisTranslatorJnaImplProvider.java
+++ b/braille/liblouis-utils/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisTranslatorJnaImplProvider.java
@@ -51,7 +51,6 @@ import static org.daisy.pipeline.braille.common.AbstractTransformProvider.util.l
 import org.daisy.pipeline.braille.common.BrailleTranslator;
 import org.daisy.pipeline.braille.common.BrailleTranslatorProvider;
 import org.daisy.pipeline.braille.common.CompoundBrailleTranslator;
-import org.daisy.pipeline.braille.common.CSSStyledText;
 import org.daisy.pipeline.braille.common.Hyphenator;
 import org.daisy.pipeline.braille.common.Hyphenator.NonStandardHyphenationException;
 import org.daisy.pipeline.braille.common.HyphenatorRegistry;
@@ -67,6 +66,7 @@ import static org.daisy.pipeline.braille.common.util.Strings.insertHyphens;
 import static org.daisy.pipeline.braille.common.util.Strings.join;
 import static org.daisy.pipeline.braille.common.util.Strings.splitInclDelimiter;
 import static org.daisy.pipeline.braille.common.util.Tuple2;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 import org.daisy.pipeline.braille.liblouis.LiblouisTable;
 import org.daisy.pipeline.braille.liblouis.LiblouisTranslator;
 import org.daisy.pipeline.braille.liblouis.impl.LiblouisTableJnaImplProvider.LiblouisTableJnaImpl;

--- a/braille/liblouis-utils/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisTranslatorJnaImplProvider.java
+++ b/braille/liblouis-utils/src/main/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisTranslatorJnaImplProvider.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import static java.util.Collections.singleton;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +18,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.size;
 import static com.google.common.collect.Iterables.toArray;
 import com.google.common.collect.Iterators;
@@ -1137,6 +1139,38 @@ public class LiblouisTranslatorJnaImplProvider extends AbstractTransformProvider
 		private List<String> transform(java.lang.Iterable<CSSStyledText> styledText,
 		                               boolean forceBraille,
 		                               boolean failWhenNonStandardHyphenation) {
+			try {
+				if (fullHyphenator == null) {
+					if (any(styledText, t -> {
+								SimpleInlineStyle style = t.getStyle();
+								return style != null && style.getProperty("hyphens") == Hyphens.AUTO; }))
+						logger.warn("hyphens: auto not supported");
+					if (lineBreaker != null)
+						throw new NonStandardHyphenationException(); }
+				else {
+					styledText = fullHyphenator.transform(styledText); }}
+			catch (NonStandardHyphenationException e) {
+				if (failWhenNonStandardHyphenation)
+					throw e;
+				else
+					switch (handleNonStandardHyphenation) {
+					case NON_STANDARD_HYPH_IGNORE:
+						logger.warn("hyphens: auto can not be applied due to non-standard hyphenation points.");
+						break;
+					case NON_STANDARD_HYPH_FAIL:
+						logger.error("hyphens: auto can not be applied due to non-standard hyphenation points.");
+						throw e;
+					case NON_STANDARD_HYPH_DEFER:
+						if (forceBraille) {
+							logger.error("hyphens: auto can not be applied due to non-standard hyphenation points.");
+							throw e; }
+						logger.debug("Deferring hyphenation to formatting phase due to non-standard hyphenation points.");
+						
+						// TODO: split up text in words and only defer the words with non-standard hyphenation
+						List<String> result = new ArrayList<>();
+						for (CSSStyledText t : styledText) result.add(t.getText());
+						return result; }}
+			
 			int size = size(styledText);
 			String[] text = new String[size];
 			SimpleInlineStyle[] style = new SimpleInlineStyle[size];
@@ -1148,20 +1182,20 @@ public class LiblouisTranslatorJnaImplProvider extends AbstractTransformProvider
 						logger.warn("Text attribute \"{}:{}\" ignored", k, attrs.get(k));
 				text[i] = t.getText();
 				style[i] = t.getStyle();
+				if (style[i] != null)
+					style[i].removeProperty("hyphens"); // handled above
 				i++; }
-			return Arrays.asList(transform(text, style, forceBraille, failWhenNonStandardHyphenation));
+			return Arrays.asList(transform(text, style));
 		}
 		
-		private String[] transform(String[] text, SimpleInlineStyle[] styles, boolean forceBraille, boolean failWhenNonStandardHyphenation) {
+		private String[] transform(String[] text, SimpleInlineStyle[] styles) {
 			int size = text.length;
 			Typeform[] typeform = new Typeform[size];
-			boolean[] hyphenate = new boolean[size];
 			boolean[] preserveLines = new boolean[size];
 			boolean[] preserveSpace = new boolean[size];
 			int[] letterSpacing = new int[size];
 			for (int i = 0; i < size; i++) {
 				typeform[i] = Typeform.PLAIN_TEXT;
-				hyphenate[i] = false;
 				preserveLines[i] = preserveSpace[i] = false;
 				letterSpacing[i] = 0;
 				SimpleInlineStyle style = styles[i];
@@ -1196,13 +1230,6 @@ public class LiblouisTranslatorJnaImplProvider extends AbstractTransformProvider
 							text[i] = textFromTextTransform(text[i], values);
 							typeform[i] = typeform[i].add(typeformFromTextTransform(values, translator, supportedTypeforms)); }
 						style.removeProperty("text-transform"); }
-					val = style.getProperty("hyphens");
-					if (val != null) {
-						if (val == Hyphens.AUTO)
-							hyphenate[i] = true;
-						else if (val == Hyphens.NONE)
-							text[i] = extractHyphens(text[i], false, SHY, ZWSP)._1;
-						style.removeProperty("hyphens"); }
 					val = style.getProperty("letter-spacing");
 					if (val != null) {
 						if (val == LetterSpacing.length) {
@@ -1216,20 +1243,18 @@ public class LiblouisTranslatorJnaImplProvider extends AbstractTransformProvider
 						if (!"white-space".equals(prop))
 							logger.warn("{}: {} not supported", prop, style.get(prop)); }}
 			
-			return transform(text, typeform, hyphenate, preserveLines, preserveSpace, letterSpacing,
-			                 forceBraille, failWhenNonStandardHyphenation);
+			return transform(text, typeform, preserveLines, preserveSpace, letterSpacing);
 		}
 		
 		private String[] transform(String[] text, Typeform[] typeform) {
 			int size = text.length;
-			boolean[] hyphenate = new boolean[size];
 			boolean[] preserveLines = new boolean[size];
 			boolean[] preserveSpace = new boolean[size];
 			int[] letterSpacing = new int[size];
-			for (int i = 0; i < hyphenate.length; i++) {
-				hyphenate[i] = preserveLines[i] = preserveSpace[i] = false;
+			for (int i = 0; i < text.length; i++) {
+				preserveLines[i] = preserveSpace[i] = false;
 				letterSpacing[i] = 0; }
-			return transform(text, typeform, hyphenate, preserveLines, preserveSpace, letterSpacing, false, false);
+			return transform(text, typeform, preserveLines, preserveSpace, letterSpacing);
 		}
 		
 		// the positions in the text where spacing must be inserted have been previously indicated with a US control character
@@ -1242,12 +1267,9 @@ public class LiblouisTranslatorJnaImplProvider extends AbstractTransformProvider
 		
 		private String[] transform(String[] text,
 		                           Typeform[] typeform,
-		                           boolean[] hyphenate,
 		                           boolean[] preserveLines,
 		                           boolean[] preserveSpace,
-		                           int[] letterSpacing,
-		                           boolean forceBraille,
-		                           boolean failWhenNonStandardHyphenation) {
+		                           int[] letterSpacing) {
 			
 			// perform Unicode normalization
 			if (unicodeNormalization != null)
@@ -1326,59 +1348,6 @@ public class LiblouisTranslatorJnaImplProvider extends AbstractTransformProvider
 					return text;
 				if (inputAttrs == null)
 					inputAttrs = new byte[lengthByCodePoints(joinedText) - 1];
-			}
-			
-			// add automatic hyphenation points to inputAttrs array
-			{
-				boolean someHyphenate = false;
-				boolean someNotHyphenate = false;
-				for (int i = 0; i < hyphenate.length; i++)
-					if (hyphenate[i]) someHyphenate = true;
-					else someNotHyphenate = true;
-				if (someHyphenate) {
-					byte[] hyphens = null;
-					try {
-						if (fullHyphenator == null) {
-							logger.warn("hyphens: auto not supported");
-							if (lineBreaker != null)
-								throw new NonStandardHyphenationException(); }
-						else {
-							hyphens = fullHyphenator.hyphenate(
-								// insert manual hyphens so that hyphenator knows which words to skip
-								insertHyphens(joinedText, inputAttrs, true, SHY, ZWSP)); }}
-					catch (NonStandardHyphenationException e) {
-						if (failWhenNonStandardHyphenation)
-							throw e;
-						else
-							switch (handleNonStandardHyphenation) {
-							case NON_STANDARD_HYPH_IGNORE:
-								logger.warn("hyphens:auto can not be applied due to non-standard hyphenation points.");
-								break;
-							case NON_STANDARD_HYPH_FAIL:
-								logger.error("hyphens:auto can not be applied due to non-standard hyphenation points.");
-								throw e;
-							case NON_STANDARD_HYPH_DEFER:
-								if (forceBraille) {
-									logger.error("hyphens:auto can not be applied due to non-standard hyphenation points.");
-									throw e; }
-								logger.debug("Deferring hyphenation to formatting phase due to non-standard hyphenation points.");
-								
-								// TODO: split up text in words and only defer the words with non-standard hyphenation
-								return text; }}
-					if (hyphens != null) {
-						if (someNotHyphenate) {
-							int i = 0;
-							for (int j = 0; j < text.length; j++) {
-								if (hyphenate[j])
-									while (i < hyphens.length && textWithWsMapping[joinedTextMapping[i]] < j + 1) i++;
-								else {
-									if (i > 0)
-										hyphens[i - 1] = 0;
-									while (i < hyphens.length && textWithWsMapping[joinedTextMapping[i]] < j + 1)
-										hyphens[i++] = 0; }}}
-						for (int i = 0; i < hyphens.length; i++)
-							// this re-adds manual SHY and ZWSP
-							inputAttrs[i] |= hyphens[i]; }}
 			}
 			
 			// add letter information to inputAttrs array
@@ -1658,7 +1627,7 @@ public class LiblouisTranslatorJnaImplProvider extends AbstractTransformProvider
 		}
 	}
 	
-	private interface FullHyphenator {
+	private interface FullHyphenator extends Hyphenator.FullHyphenator {
 		public byte[] hyphenate(String text);
 	}
 	
@@ -1697,8 +1666,16 @@ public class LiblouisTranslatorJnaImplProvider extends AbstractTransformProvider
 			this.hyphenator = hyphenator.asFullHyphenator();
 		}
 		
+		public java.lang.Iterable<CSSStyledText> transform(java.lang.Iterable<CSSStyledText> text) {
+			return hyphenator.transform(text);
+		}
+		
+		private final static SimpleInlineStyle HYPHENS_AUTO = new SimpleInlineStyle("hyphens: auto");
+		
 		public byte[] hyphenate(String text) {
-			return extractHyphens(hyphenator.transform(text), true, SHY, ZWSP)._2;
+			return extractHyphens(
+				hyphenator.transform(singleton(new CSSStyledText(text, HYPHENS_AUTO))).iterator().next().getText(),
+				true, SHY, ZWSP)._2;
 		}
 	}
 	

--- a/braille/liblouis-utils/src/test/java/LiblouisCoreTest.java
+++ b/braille/liblouis-utils/src/test/java/LiblouisCoreTest.java
@@ -337,9 +337,15 @@ public class LiblouisCoreTest extends AbstractTest {
 			"abc-\n" +
 			"def \n" +
 			"abc'\n" +
+			"def \n" +
+			"abc'\n" +
 			"def",
 			fillLines(translator.transform(styledText("abc\u00ADdef ", "",
-			                                          "abc\u00ADdef", "hyphenate-character: '⠈'")), 4));
+			                                          "abc\u00ADdef ", "hyphenate-character: '⠈'",
+			                                          "ab",            "",
+			                                          "c\u00ADd",      "hyphenate-character: '⠈'",
+			                                          "ef",            "")),
+			          4));
 	}
 	
 	@Test

--- a/braille/liblouis-utils/src/test/java/LiblouisCoreTest.java
+++ b/braille/liblouis-utils/src/test/java/LiblouisCoreTest.java
@@ -349,6 +349,36 @@ public class LiblouisCoreTest extends AbstractTest {
 	}
 	
 	@Test
+	public void testTranslateAndHyphenateCompoundWord() {
+		FromStyledTextToBraille translator = provider.withContext(messageBus)
+		                                             .get(query("(table:'foobar.utb,foobar.dic')(hyphenator:auto)")).iterator().next()
+		                                             .fromStyledTextToBraille();
+		assertEquals(
+			braille("⠋⠕⠕⠤\u200B⠃⠁⠗"),
+			translator.transform(styledText("foo-bar", "hyphens:auto")));
+		// break opportunity expected after '-' regardless of value of hyphens
+		assertEquals(
+			braille("⠋⠕⠕⠤\u200B⠃⠁⠗"),
+			translator.transform(styledText("foo-bar", "hyphens:manual")));
+		assertEquals(
+			braille("⠋⠕⠕⠤\u200B⠃⠁⠗"),
+			translator.transform(styledText("foo-bar", "hyphens:none")));
+		// and regardless of value of hyphenator feature
+		translator = provider.withContext(messageBus)
+		                     .get(query("(table:'foobar.utb,foobar.dic')(hyphenator:none)")).iterator().next()
+		                    .fromStyledTextToBraille();
+		assertEquals(
+			braille("⠋⠕⠕⠤\u200B⠃⠁⠗"),
+			translator.transform(styledText("foo-bar", "hyphens:auto")));
+		assertEquals(
+			braille("⠋⠕⠕⠤\u200B⠃⠁⠗"),
+			translator.transform(styledText("foo-bar", "hyphens:manual")));
+		assertEquals(
+			braille("⠋⠕⠕⠤\u200B⠃⠁⠗"),
+			translator.transform(styledText("foo-bar", "hyphens:none")));
+	}
+	
+	@Test
 	public void testTranslateAndHyphenateNonStandard() {
 		LineBreakingFromStyledText translator = provider.withContext(messageBus)
 		                                                .get(query("(table:'foobar.ctb')(hyphenator:mock)(charset:'foobar.dis')")).iterator().next()

--- a/braille/liblouis-utils/src/test/java/LiblouisCoreTest.java
+++ b/braille/liblouis-utils/src/test/java/LiblouisCoreTest.java
@@ -285,29 +285,29 @@ public class LiblouisCoreTest extends AbstractTest {
 	
 	@Test
 	public void testHyphenate() {
-		assertEquals("foo\u00ADbar",
+		assertEquals(text("foo\u00ADbar"),
 		             hyphenatorProvider.withContext(messageBus)
 		                 .get(query("(table:'foobar.uti,foobar.dic')")).iterator().next()
 		                 .asFullHyphenator()
-		                 .transform("foobar"));
+		                 .transform(styledText("foobar", "hyphens: auto")));
 	}
 	
 	@Test
 	public void testHyphenateCompoundWord() {
-		assertEquals("foo-\u200Bbar",
+		assertEquals(text("foo-\u200Bbar"),
 		             hyphenatorProvider.withContext(messageBus)
 		                 .get(query("(table:'foobar.uti,foobar.dic')")).iterator().next()
 		                 .asFullHyphenator()
-		                 .transform("foo-bar"));
+		                 .transform(styledText("foo-bar", "hyphens: auto")));
 	}
 	
 	@Test
 	public void testManualWordBreak() {
-		assertEquals("foo\u00ADbar foo\u00ADbar foob\u00ADar",
+		assertEquals(text("foo\u00ADbar foo\u00ADbar foob\u00ADar"),
 		             hyphenatorProvider.withContext(messageBus)
 		                 .get(query("(table:'foobar.uti,foobar.dic')")).iterator().next()
 		                 .asFullHyphenator()
-		                 .transform("foobar foo\u00ADbar foob\u00ADar"));
+		                 .transform(styledText("foobar foo\u00ADbar foob\u00ADar", "hyphens: auto")));
 		assertEquals(braille("⠋⠕⠕\u00AD⠃⠁⠗ ⠋⠕⠕\u00AD⠃⠁⠗ ⠋⠕⠕⠃\u00AD⠁⠗"),
 		             provider.withContext(messageBus)
 		                     .get(query("(table:'foobar.uti,foobar.dic')")).iterator().next()

--- a/braille/liblouis-utils/src/test/java/LiblouisCoreTest.java
+++ b/braille/liblouis-utils/src/test/java/LiblouisCoreTest.java
@@ -21,12 +21,12 @@ import org.daisy.pipeline.braille.common.BrailleTranslator.FromStyledTextToBrail
 import org.daisy.pipeline.braille.common.BrailleTranslator.LineBreakingFromStyledText;
 import org.daisy.pipeline.braille.common.BrailleTranslator.LineIterator;
 import org.daisy.pipeline.braille.common.CompoundBrailleTranslator;
-import org.daisy.pipeline.braille.common.CSSStyledText;
 import org.daisy.pipeline.braille.common.Hyphenator;
 import org.daisy.pipeline.braille.common.Provider;
 import org.daisy.pipeline.braille.common.TransformProvider;
 import static org.daisy.pipeline.braille.common.Query.util.query;
 import static org.daisy.pipeline.braille.common.util.Files.asFile;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 import org.daisy.pipeline.braille.liblouis.LiblouisHyphenator;
 import org.daisy.pipeline.braille.liblouis.LiblouisTable;
 import org.daisy.pipeline.braille.liblouis.LiblouisTableResolver;

--- a/braille/liblouis-utils/src/test/java/LiblouisTablesTest.java
+++ b/braille/liblouis-utils/src/test/java/LiblouisTablesTest.java
@@ -7,8 +7,8 @@ import javax.inject.Inject;
 
 import com.google.common.base.Optional;
 
-import org.daisy.pipeline.braille.common.CSSStyledText;
 import static org.daisy.pipeline.braille.common.Query.util.query;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 import org.daisy.pipeline.braille.liblouis.LiblouisTranslator;
 
 import org.daisy.pipeline.junit.AbstractTest;

--- a/braille/liblouis-utils/src/test/java/MockHyphenator.java
+++ b/braille/liblouis-utils/src/test/java/MockHyphenator.java
@@ -7,6 +7,7 @@ import org.daisy.pipeline.braille.common.AbstractTransformProvider;
 import org.daisy.pipeline.braille.common.HyphenatorProvider;
 import org.daisy.pipeline.braille.common.Query;
 import static org.daisy.pipeline.braille.common.Query.util.query;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -26,10 +27,7 @@ public class MockHyphenator extends AbstractHyphenator {
 	};
 	
 	private static final FullHyphenator fullHyphenator = new FullHyphenator() {
-		public String transform(String text) throws NonStandardHyphenationException {
-			throw new NonStandardHyphenationException();
-		}
-		public String[] transform(String[] text) throws NonStandardHyphenationException {
+		public Iterable<CSSStyledText> transform(Iterable<CSSStyledText> text) throws NonStandardHyphenationException {
 			throw new NonStandardHyphenationException();
 		}
 	};

--- a/braille/liblouis-utils/src/test/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisTranslatorJnaImplTest.java
+++ b/braille/liblouis-utils/src/test/java/org/daisy/pipeline/braille/liblouis/impl/LiblouisTranslatorJnaImplTest.java
@@ -16,10 +16,10 @@ import org.daisy.braille.css.SimpleInlineStyle;
 import static org.daisy.common.file.URLs.asURL;
 
 import org.daisy.pipeline.braille.common.AbstractHyphenator;
-import org.daisy.pipeline.braille.common.CSSStyledText;
 import org.daisy.pipeline.braille.common.Hyphenator;
 import org.daisy.pipeline.braille.common.NativePath;
 import static org.daisy.pipeline.braille.common.util.Files.asFile;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 import org.daisy.pipeline.braille.liblouis.impl.LiblouisTranslatorJnaImplProvider.LiblouisTranslatorImpl;
 import org.daisy.pipeline.junit.OSGiLessRunner;
 

--- a/braille/texhyph-utils/src/main/java/org/daisy/pipeline/braille/tex/impl/TexHyphenatorDotifyImpl.java
+++ b/braille/texhyph-utils/src/main/java/org/daisy/pipeline/braille/tex/impl/TexHyphenatorDotifyImpl.java
@@ -16,6 +16,7 @@ import net.davidashen.text.Utf8TexParser.TexParserException;
 
 import org.daisy.common.file.URLs;
 import org.daisy.pipeline.braille.common.AbstractHyphenator;
+import org.daisy.pipeline.braille.common.AbstractHyphenator.util.DefaultFullHyphenator;
 import org.daisy.pipeline.braille.common.AbstractTransformProvider;
 import org.daisy.pipeline.braille.common.AbstractTransformProvider.util.Function;
 import org.daisy.pipeline.braille.common.AbstractTransformProvider.util.Iterables;
@@ -27,6 +28,8 @@ import org.daisy.pipeline.braille.common.Query.MutableQuery;
 import static org.daisy.pipeline.braille.common.Query.util.mutableQuery;
 import static org.daisy.pipeline.braille.common.util.Files.isAbsoluteFile;
 import static org.daisy.pipeline.braille.common.util.Locales.parseLocale;
+import static org.daisy.pipeline.braille.common.util.Strings.extractHyphens;
+import static org.daisy.pipeline.braille.common.util.Tuple2;
 import org.daisy.pipeline.braille.tex.TexHyphenator;
 
 import org.osgi.service.component.annotations.Activate;
@@ -210,31 +213,24 @@ public class TexHyphenatorDotifyImpl extends AbstractTransformProvider<TexHyphen
 			return fullHyphenator;
 		}
 		
-		private final FullHyphenator fullHyphenator = new FullHyphenator() {
-			public String transform(String text) {
-				return TexHyphenatorImpl.this.transform(text);
-			}
-			public String[] transform(String[] text) {
-				return TexHyphenatorImpl.this.transform(text);
-			}
-		};
+		private final FullHyphenator fullHyphenator = new DefaultFullHyphenator() {
+
+				private final static char SHY = '\u00AD';
+				private final static char ZWSP = '\u200B';
+
+				protected boolean isCodePointAware() { return true; }
 		
-		public String transform(String text) {
-			try {
-				return hyphenator.hyphenate(text, beginLimit, endLimit); }
-			catch (Exception e) {
-				throw new RuntimeException("Error during TeX hyphenation", e); }
-		}
-		
-		public String[] transform(String[] text) {
-			String[] hyphenated = new String[text.length];
-			for (int i = 0; i < text.length; i++)
-				try {
-					hyphenated[i] = hyphenator.hyphenate(text[i], beginLimit, endLimit); }
-				catch (Exception e) {
-					throw new RuntimeException("Error during TeX hyphenation", e); }
-			return hyphenated;
-		}
+				protected byte[] getHyphenationOpportunities(String textWithoutHyphens) throws RuntimeException {
+					try {
+						Tuple2<String,byte[]> t = extractHyphens(
+							hyphenator.hyphenate(textWithoutHyphens, beginLimit, endLimit), true, SHY, ZWSP);
+						if (!t._1.equals(textWithoutHyphens))
+							throw new RuntimeException("Unexpected output from " + hyphenator);
+						return t._2; }
+					catch (Exception e) {
+						throw new RuntimeException("Error during TeX hyphenation", e); }
+				}
+			};
 	}
 	
 	@Override

--- a/braille/texhyph-utils/src/main/java/org/daisy/pipeline/braille/tex/impl/TexHyphenatorSimpleImpl.java
+++ b/braille/texhyph-utils/src/main/java/org/daisy/pipeline/braille/tex/impl/TexHyphenatorSimpleImpl.java
@@ -11,6 +11,7 @@ import com.google.common.base.MoreObjects.ToStringHelper;
 
 import org.daisy.common.file.URLs;
 import org.daisy.pipeline.braille.common.AbstractHyphenator;
+import org.daisy.pipeline.braille.common.AbstractHyphenator.util.DefaultFullHyphenator;
 import org.daisy.pipeline.braille.common.AbstractTransformProvider;
 import org.daisy.pipeline.braille.common.AbstractTransformProvider.util.Function;
 import org.daisy.pipeline.braille.common.AbstractTransformProvider.util.Iterables;
@@ -22,6 +23,8 @@ import org.daisy.pipeline.braille.common.Query.MutableQuery;
 import static org.daisy.pipeline.braille.common.Query.util.mutableQuery;
 import static org.daisy.pipeline.braille.common.util.Files.isAbsoluteFile;
 import static org.daisy.pipeline.braille.common.util.Locales.parseLocale;
+import static org.daisy.pipeline.braille.common.util.Strings.extractHyphens;
+import static org.daisy.pipeline.braille.common.util.Tuple2;
 import org.daisy.pipeline.braille.tex.TexHyphenator;
 
 import org.osgi.service.component.annotations.Activate;
@@ -140,31 +143,24 @@ public class TexHyphenatorSimpleImpl extends AbstractTransformProvider<TexHyphen
 			return fullHyphenator;
 		}
 		
-		private final FullHyphenator fullHyphenator = new FullHyphenator() {
-			public String transform(String text) {
-				return TexHyphenatorImpl.this.transform(text);
-			}
-			public String[] transform(String[] text) {
-				return TexHyphenatorImpl.this.transform(text);
-			}
-		};
+		private final FullHyphenator fullHyphenator = new DefaultFullHyphenator() {
+
+				private final static char SHY = '\u00AD';
+				private final static char ZWSP = '\u200B';
+
+				protected boolean isCodePointAware() { return true; }
 		
-		public String transform(String text) {
-			try {
-				return hyphenator.hyphenate(text); }
-			catch (Exception e) {
-				throw new RuntimeException("Error during TeX hyphenation", e); }
-		}
-		
-		public String[] transform(String[] text) {
-			String[] hyphenated = new String[text.length];
-			for (int i = 0; i < text.length; i++)
-				try {
-					hyphenated[i] = hyphenator.hyphenate(text[i]); }
-				catch (Exception e) {
-					throw new RuntimeException("Error during TeX hyphenation", e); }
-			return hyphenated;
-		}
+				protected byte[] getHyphenationOpportunities(String textWithoutHyphens) throws RuntimeException {
+					try {
+						Tuple2<String,byte[]> t = extractHyphens(
+							hyphenator.hyphenate(textWithoutHyphens), true, SHY, ZWSP);
+						if (!t._1.equals(textWithoutHyphens))
+							throw new RuntimeException("Unexpected output from " + hyphenator);
+						return t._2; }
+					catch (Exception e) {
+						throw new RuntimeException("Error during TeX hyphenation", e); }
+				}
+			};
 	}
 	
 	private URL resolveTable(URI table) {

--- a/braille/texhyph-utils/src/test/java/TexHyphenatorCoreTest.java
+++ b/braille/texhyph-utils/src/test/java/TexHyphenatorCoreTest.java
@@ -1,7 +1,10 @@
+import java.util.ArrayList;
+import java.util.List;
 import javax.inject.Inject;
 
 import static org.daisy.pipeline.braille.common.Query.util.query;
 import org.daisy.pipeline.braille.common.HyphenatorRegistry;
+import org.daisy.pipeline.braille.css.CSSStyledText;
 
 import org.daisy.pipeline.junit.AbstractTest;
 
@@ -18,24 +21,46 @@ public class TexHyphenatorCoreTest extends AbstractTest {
 	
 	@Test
 	public void testHyphenate() {
-		assertEquals("foo\u00ADbar",
+		assertEquals(text("foo\u00ADbar"),
 		             provider.get(query("(table:'foobar.tex')")).iterator().next()
 		                     .asFullHyphenator()
-		                     .transform("foobar"));
-		assertEquals("foo-\u200Bbar",
+		                     .transform(styledText("foobar", "hyphens: auto")));
+		assertEquals(text("foo-\u200Bbar"),
 		             provider.get(query("(table:'foobar.tex')")).iterator().next()
 		                     .asFullHyphenator()
-		                     .transform("foo-bar"));
-		assertEquals("foo\u00ADbar",
+		                     .transform(styledText("foo-bar", "hyphens: auto")));
+		assertEquals(text("foo\u00ADbar"),
 		             provider.get(query("(table:'foobar.properties')")).iterator().next()
 		                     .asFullHyphenator()
-		                     .transform("foobar"));
-		assertEquals("foo-\u200Bbar",
+		                     .transform(styledText("foobar", "hyphens: auto")));
+		assertEquals(text("foo-\u200Bbar"),
 		             provider.get(query("(table:'foobar.properties')")).iterator().next()
 		                     .asFullHyphenator()
-		                     .transform("foo-bar"));
+		                     .transform(styledText("foo-bar", "hyphens: auto")));
 	}
-	
+
+	private Iterable<CSSStyledText> styledText(String... textAndStyle) {
+		List<CSSStyledText> styledText = new ArrayList<CSSStyledText>();
+		String text = null;
+		boolean textSet = false;
+		for (String s : textAndStyle) {
+			if (textSet)
+				styledText.add(new CSSStyledText(text, s));
+			else
+				text = s;
+			textSet = !textSet; }
+		if (textSet)
+			throw new RuntimeException();
+		return styledText;
+	}
+
+	private Iterable<CSSStyledText> text(String... text) {
+		List<CSSStyledText> styledText = new ArrayList<CSSStyledText>();
+		for (String t : text)
+			styledText.add(new CSSStyledText(t, ""));
+		return styledText;
+	}
+
 	@Override
 	protected String[] testDependencies() {
 		return new String[] {


### PR DESCRIPTION
- Recompile Libhyphen table linked using relative path from within `@text-transform` rule
- Wrapping of compound words with hyphen should not be influenced by hyphens property
- Other bugfixes
- Improve `Hyphenator` API: `FullHyphenator` now accepts and returns a sequence of `CSSStyledText` and must take into account the "hyphens" property
- Code refactoring