### PR TITLE
[dtbook-to-odt] replace bash by ant for templates zipping

### DIFF
--- a/scripts/dtbook-to-odt/pom.xml
+++ b/scripts/dtbook-to-odt/pom.xml
@@ -87,32 +87,40 @@
     </resources>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>shell-maven-plugin</artifactId>
-        <version>1.0-beta-1</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>ant-contrib</groupId>
+            <artifactId>ant-contrib</artifactId>
+            <version>1.0b3</version>
+            <exclusions>
+              <exclusion>
+                <groupId>ant</groupId>
+                <artifactId>ant</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant-nodeps</artifactId>
+            <version>1.8.1</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
-            <id>generate-ott</id>
+            <id>generate-ott-ant</id>
             <phase>generate-resources</phase>
             <goals>
-              <goal>shell</goal>
+              <goal>run</goal>
             </goals>
             <configuration>
-              <workDir>${project.basedir}</workDir>
-              <chmod>true</chmod>
-              <script>
-                #!/bin/sh
-                zip_odt() {
-                  cd $1
-                  zip -0 -X $2 mimetype
-                  zip -r $2 * -x mimetype
-                }
-                rm -rf target/generated-resources/templates
-                mkdir -p target/generated-resources/templates
-                for template in $(ls src/main/resources/templates); do
-                  (zip_odt src/main/resources/templates/${template} $(pwd)/target/generated-resources/templates/${template})
-                done
-              </script>
+              <target>
+                <ant antfile="${project.basedir}/zip-templates.xml">
+                  <target name="dist"/>
+                </ant>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/scripts/dtbook-to-odt/zip-templates.xml
+++ b/scripts/dtbook-to-odt/zip-templates.xml
@@ -1,0 +1,31 @@
+<project name="zip_templates" default="dist" basedir="./">
+    <taskdef resource="net/sf/antcontrib/antlib.xml"/>
+    <!-- to be called by maven-->
+    <target name="dist">
+        <delete dir="${basedir}/target/generated-resources/templates"/>
+        <mkdir dir="${basedir}/target/generated-resources/templates"/>
+        <!--for each folder in src/main/resources/templates, create a template archive -->
+        <foreach target="zip_odt" param="template">
+            <path>
+                <dirset dir="src/main/resources/templates/" includes="*"/>
+            </path>
+        </foreach>
+    </target>
+    <target name="zip_odt">
+        <basename property="templateName" file="${template}"/>
+        <!-- create a zip of the same name in ${project.basedir}/target/generated-resources/templates -->
+        <!-- add the mimetype file uncompressed (-0) without extra attributes (-X, defaults with ant zip)  -->
+        <zip destFile="${basedir}/target/generated-resources/templates/${templateName}"
+             basedir="${template}"
+             includes="mimetype"
+             compress="false" keepcompression="false" />
+        <!-- add all remaining files and folder into the zip
+        -->
+        <zip destFile="${basedir}/target/generated-resources/templates/${templateName}"
+             basedir="${template}"
+             update="true"
+             includes="**/**"
+             excludes="mimetype"
+             compress="true" keepcompression="false"/>
+    </target>
+</project>


### PR DESCRIPTION
Small PR to remove bash calls from the dtbook-to-odt.

This replaces the need of bash installed on Windows by a build-limited dependency to Ant (managed by maven) for building the zipped templates in the module build process.