### PR TITLE
[modules] tts-sapinative: fix sapi voice key resolution

### DIFF
--- a/tts/tts-adapters/tts-adapter-sapinative/src/main/java/org/daisy/pipeline/tts/sapi/impl/SAPIEngine.java
+++ b/tts/tts-adapters/tts-adapter-sapinative/src/main/java/org/daisy/pipeline/tts/sapi/impl/SAPIEngine.java
@@ -82,7 +82,13 @@ public class SAPIEngine extends TTSEngine {
 	public AudioInputStream speak(String ssml, Voice voice, TTSResource resource, List<Integer> marks)
 			throws SynthesisException {
 
-		voice = mVoiceFormatConverter.get(voice.getName().toLowerCase());
+		String key = voice.getName().toLowerCase();
+		// To avoid using sapi when onecore is available
+		// the "desktop" suffix is removed from the hashmap keys for sapi languages
+		if (key.endsWith(" desktop")) {
+			key = key.substring(0,key.length() - " desktop".length());
+		}
+		voice = mVoiceFormatConverter.get(key);
 		NativeSynthesisResult res;
 		// Speak
 		if (voice.getEngine().equals("sapi") ){


### PR DESCRIPTION
Fixing an issue in SAPI voice resolution, where SAPI voices are not found back in the voices hashmap :
" Desktop" suffix is deleted from the hash in the `getAvailableVoices` method, to prioritize onecore voices over sapi when possible.

When searching back voices in the voices map, delete the desktop suffix of sapi voices.

