### PR TITLE
dtbook-cleaner: also copy dtbook resources along the cleaning process

### DIFF
--- a/scripts-utils/dtbook-utils/src/main/resources/xml/fix-dtbook/dtbook-cleaner.script.xpl
+++ b/scripts-utils/dtbook-utils/src/main/resources/xml/fix-dtbook/dtbook-cleaner.script.xpl
@@ -109,6 +109,19 @@ if MathML is present in the document.</p>
         </p:documentation>
     </p:option>
 
+    <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
+
+    <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl">
+        <p:documentation>
+            px:fileset-add-entry
+            px:fileset-copy
+            px:fileset-filter
+            px:fileset-store
+        </p:documentation>
+    </p:import>
+
+    <p:import href="../dtbook-load.xpl" />
+
     <p:import href="http://www.daisy.org/pipeline/modules/dtbook-break-detection/library.xpl">
         <p:documentation>
             px:dtbook-break-detect
@@ -133,45 +146,66 @@ if MathML is present in the document.</p>
 
     <p:for-each px:message="Cleaning DTBook(s)">
         <p:variable name="output-name" select="concat(replace(replace(base-uri(.),'^.*/([^/]+)$','$1'),'\.[^\.]*$',''),'.xml')"/>
-        <!-- Update the DTBook -->
-        <px:dtbook-upgrade/>
-        <!-- Apply routines -->
-        <pxi:dtbook-fix>
-            <p:with-option name="repair" select="$repair='true'"/>
-            <p:with-option name="tidy" select="$tidy='true'"/>
-            <p:with-option name="simplifyHeadingLayout" select="$simplifyHeadingLayout='true'"/>
-            <p:with-option name="externalizeWhitespace" select="$externalizeWhitespace='true'"/>
-            <p:with-option name="documentLanguage" select="$documentLanguage='true'"/>
-            <p:with-option name="narrator" select="$narrator='true'"/>
-            <p:with-option name="publisher" select="$publisher='true'"/>
-        </pxi:dtbook-fix>
-
-        <p:choose>
-            <p:when test="$ApplySentenceDetection='true'">
-                <px:dtbook-break-detect/>
-                <px:dtbook-unwrap-words/>
-            </p:when>
-            <p:otherwise>
-                <p:identity/>
-            </p:otherwise>
-        </p:choose>
-
-        <!--
-            FIXME: this should be handled with px:fileset-store
-        -->
-        <p:choose>
-            <p:when test="$WithDoctype='true'">
-                <!-- DTBook with doctype (result is serialized) -->
-                <pxi:dtbook-doctyping/>
-            </p:when>
-            <p:otherwise>
-                <p:identity/>
-            </p:otherwise>
-        </p:choose>
-        <!-- Store on disk -->
-        <p:store>
+        <px:message message="Cleaning '$1' ...">
+            <p:with-option name="param1" select="$output-name"/>
+        </px:message>
+        <p:group name="cleaned-document">
+            <p:output primary="true" port="result" />
+            <!-- Update the DTBook -->
+            <px:dtbook-upgrade/>
+            <!-- Apply routines -->
+            <pxi:dtbook-fix>
+                <p:with-option name="repair" select="$repair='true'"/>
+                <p:with-option name="tidy" select="$tidy='true'"/>
+                <p:with-option name="simplifyHeadingLayout" select="$simplifyHeadingLayout='true'"/>
+                <p:with-option name="externalizeWhitespace" select="$externalizeWhitespace='true'"/>
+                <p:with-option name="documentLanguage" select="$documentLanguage='true'"/>
+                <p:with-option name="narrator" select="$narrator='true'"/>
+                <p:with-option name="publisher" select="$publisher='true'"/>
+            </pxi:dtbook-fix>
+            <p:choose>
+                <p:when test="$ApplySentenceDetection='true'">
+                    <px:dtbook-break-detect/>
+                    <px:dtbook-unwrap-words/>
+                </p:when>
+                <p:otherwise>
+                    <p:identity/>
+                </p:otherwise>
+            </p:choose>
+            <p:choose>
+                <p:when test="$WithDoctype='true'">
+                    <!-- DTBook with doctype (result is serialized) -->
+                    <pxi:dtbook-doctyping/>
+                </p:when>
+                <p:otherwise>
+                    <p:identity/>
+                </p:otherwise>
+            </p:choose>
+        </p:group>
+        <p:store px:message="Storing the cleaned DTBook and its resources ...">
             <p:with-option name="href" select="concat(resolve-uri($result),$output-name)"/>
         </p:store>
+        <!-- Copying dtbook side resources -->
+        <px:fileset-add-entry media-type="application/x-dtbook+xml" name="dtbook">
+            <p:input port="entry">
+                <p:pipe step="cleaned-document" port="result"/>
+            </p:input>
+        </px:fileset-add-entry>
+        <px:dtbook-load name="load" />
+        <px:fileset-filter not-media-types="application/x-dtbook+xml"/>
+        <px:fileset-copy name="copy">
+            <p:with-option name="target" select="resolve-uri($result)"/>
+        </px:fileset-copy>
+        <px:fileset-store>
+            <p:input port="fileset.in">
+                <p:pipe port="result.fileset" step="copy"/>
+            </p:input>
+            <p:input port="in-memory.in">
+                <p:pipe port="result.in-memory" step="copy"/>
+            </p:input>
+        </px:fileset-store>
+
+
     </p:for-each>
 
 </p:declare-step>


### PR DESCRIPTION
Makes the cleaning script to also copy the dtbooks' resources int the result directory.

This is to make it easier to include the script in a chain of conversion.